### PR TITLE
Dev 5858/deleted products are null

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -23,7 +23,12 @@ runs:
     - name: Install dependencies
       shell: bash
       run: |
-        composer install --no-dev --optimize-autoloader
+        composer install --optimize-autoloader
+        
+    - name: Run unit tests
+      shell: bash
+      run: |
+        vendor/bin/phpunit Test/Unit/ --testdox
         
     - name: Run integration tests
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,11 @@ jobs:
         
     - name: Install dependencies
       run: |
-        composer install --no-dev --optimize-autoloader
+        composer install --optimize-autoloader
+        
+    - name: Run Unit Tests
+      run: |
+        vendor/bin/phpunit Test/Unit/ --testdox
         
     - name: Run Integration Tests
       run: |

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
-.PHONY: test test-local test-compatibility lint lint-fix help
+.PHONY: test test-local test-unit test-compatibility lint lint-fix help
 
 # Default target
 help:
 	@echo "Available commands:"
 	@echo "  make test              - Run all tests using Docker"
 	@echo "  make test-local        - Run all tests locally (requires PHP)"
+	@echo "  make test-unit         - Run unit tests only"
 	@echo "  make test-compatibility - Run Adobe Commerce 2.4.8-p1 compatibility tests"
 	@echo "  make lint              - Run PHP CodeSniffer linting"
 	@echo "  make lint-fix          - Auto-fix linting issues where possible"
@@ -18,10 +19,16 @@ test:
 # Run tests locally (requires PHP)
 test-local:
 	@echo "Running all tests locally..."
+	@vendor/bin/phpunit Test/Unit/ --testdox
 	@for test_file in Test/Integration/*.php; do \
 		echo "Running $$test_file..."; \
 		php "$$test_file"; \
 	done
+
+# Run unit tests only
+test-unit:
+	@echo "Running unit tests..."
+	@vendor/bin/phpunit Test/Unit/ --testdox
 
 # Run Adobe Commerce 2.4.8-p1 compatibility tests
 test-compatibility:

--- a/Model/Api.php
+++ b/Model/Api.php
@@ -614,7 +614,7 @@ class Api
             $cartItems[] = array(
                 'ItemID' => 'shipping',
                 'Index' => $index,
-                'TIC' => $this->_getShippingTic(),
+                'TIC' => $this->productTicService->getShippingTic(),
                 'Price' => $shippingAmount,
                 'Qty' => 1,
             );
@@ -698,8 +698,12 @@ class Api
 
         $returnResult = $obj->getResult();
 
-        if ($returnResult['ResponseType'] != 'OK') {
-            $this->_tclogger->info('Error encountered during returnOrder: ' . $returnResult['Messages']['ResponseMessage']['Message']);
+        if (!$returnResult || $returnResult['ResponseType'] != 'OK') {
+            $errorMessage = 'Unknown error';
+            if ($returnResult && isset($returnResult['Messages']['ResponseMessage']['Message'])) {
+                $errorMessage = $returnResult['Messages']['ResponseMessage']['Message'];
+            }
+            $this->_tclogger->info('Error encountered during returnOrder: ' . $errorMessage);
             return false;
         }
 

--- a/Model/Api.php
+++ b/Model/Api.php
@@ -117,6 +117,13 @@ class Api
     private $cartItemResponseHandler;
 
     /**
+     * Product TIC Service
+     *
+     * @var \Taxcloud\Magento2\Model\ProductTicService
+     */
+    private $productTicService;
+
+    /**
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\Framework\App\CacheInterface $cacheType
      * @param \Magento\Framework\Event\ManagerInterface $eventManager
@@ -125,6 +132,9 @@ class Api
      * @param \Magento\Catalog\Model\ProductFactory $productFactory
      * @param \Magento\Directory\Model\RegionFactory $regionFactory
      * @param \Taxcloud\Magento2\Logger\Logger $tclogger
+     * @param SerializerInterface $serializer
+     * @param \Taxcloud\Magento2\Model\CartItemResponseHandler $cartItemResponseHandler
+     * @param \Taxcloud\Magento2\Model\ProductTicService $productTicService
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -137,7 +147,8 @@ class Api
         \Magento\Directory\Model\RegionFactory $regionFactory,
         \Taxcloud\Magento2\Logger\Logger $tclogger,
         SerializerInterface $serializer,
-        \Taxcloud\Magento2\Model\CartItemResponseHandler $cartItemResponseHandler
+        \Taxcloud\Magento2\Model\CartItemResponseHandler $cartItemResponseHandler,
+        \Taxcloud\Magento2\Model\ProductTicService $productTicService
     ) {
         $this->_scopeConfig = $scopeConfig;
         $this->_cacheType = $cacheType;
@@ -148,6 +159,7 @@ class Api
         $this->_regionFactory = $regionFactory;
         $this->serializer = $serializer;
         $this->cartItemResponseHandler = $cartItemResponseHandler;
+        $this->productTicService = $productTicService;
         if ($scopeConfig->getValue('tax/taxcloud_settings/logging', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)) {
             $this->_tclogger = $tclogger;
         } else {
@@ -186,23 +198,6 @@ class Api
         return $this->_scopeConfig->getValue('tax/taxcloud_settings/guest_customer_id', \Magento\Store\Model\ScopeInterface::SCOPE_STORE) ?? '-1';
     }
 
-    /**
-     * Get TaxCloud Default Product TIC
-     * @return string
-     */
-    protected function _getDefaultTic()
-    {
-        return $this->_scopeConfig->getValue('tax/taxcloud_settings/default_tic', \Magento\Store\Model\ScopeInterface::SCOPE_STORE) ?? '00000';
-    }
-
-    /**
-     * Get TaxCloud Default Shipping TIC
-     * @return string
-     */
-    protected function _getShippingTic()
-    {
-        return $this->_scopeConfig->getValue('tax/taxcloud_settings/shipping_tic', \Magento\Store\Model\ScopeInterface::SCOPE_STORE) ?? '11010';
-    }
 
     /**
      * Get TaxCloud Cache Lifetime
@@ -331,16 +326,14 @@ class Api
         if (isset($itemsByType[self::ITEM_TYPE_PRODUCT])) {
             foreach ($itemsByType[self::ITEM_TYPE_PRODUCT] as $code => $itemTaxDetail) {
                 $item = $keyedAddressItems[$code];
-                if ($item->getProduct()->getTaxClassId() === '0') {
+                if ($item->getProduct() && $item->getProduct()->getTaxClassId() === '0') {
                     // Skip products with tax_class_id of None, store owners should avoid doing this
                     continue;
                 }
-                $productModel = $this->_productFactory->create()->load($item->getProduct()->getId());
-                $tic = $productModel->getCustomAttribute('taxcloud_tic');
                 $cartItems[] = array(
                     'ItemID' => $item->getSku(),
                     'Index' => $index,
-                    'TIC' => $tic ? $tic->getValue() : $this->_getDefaultTic(),
+                    'TIC' => $this->productTicService->getProductTic($item, 'lookupTaxes'),
                     'Price' => $item->getPrice() - $item->getDiscountAmount() / $item->getQty(),
                     'Qty' => $item->getQty(),
                 );
@@ -354,7 +347,7 @@ class Api
                 $cartItems[] = array(
                     'ItemID' => 'shipping',
                     'Index' => $index++,
-                    'TIC' => $this->_getShippingTic(),
+                    'TIC' => $this->productTicService->getShippingTic(),
                     'Price' => $itemTaxDetail[self::KEY_ITEM]->getRowTotal(),
                     'Qty' => 1,
                 );
@@ -604,12 +597,10 @@ class Api
         if ($items) {
             foreach ($items as $creditItem) {
                 $item = $creditItem->getOrderItem();
-                $productModel = $this->_productFactory->create()->load($item->getProduct()->getId());
-                $tic = $productModel->getCustomAttribute('taxcloud_tic');
                 $cartItems[] = array(
                     'ItemID' => $item->getSku(),
                     'Index' => $index,
-                    'TIC' => $tic ? $tic->getValue() : $this->_getDefaultTic(),
+                    'TIC' => $this->productTicService->getProductTic($item, 'returnOrder'),
                     'Price' => $creditItem->getPrice() - $creditItem->getDiscountAmount() / $creditItem->getQty(),
                     'Qty' => $creditItem->getQty(),
                 );

--- a/Model/ProductTicService.php
+++ b/Model/ProductTicService.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Taxcloud_Magento2
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @package    Taxcloud_Magento2
+ * @author     TaxCloud <service@taxcloud.net>
+ * @copyright  2021 The Federal Tax Authority, LLC d/b/a TaxCloud
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+namespace Taxcloud\Magento2\Model;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Catalog\Model\ProductFactory;
+use Taxcloud\Magento2\Logger\Logger;
+
+/**
+ * Service for handling Product TIC (Taxability Information Code) logic
+ * Handles cases where products have been deleted or don't have custom TIC attributes
+ */
+class ProductTicService
+{
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * @var ProductFactory
+     */
+    private $productFactory;
+
+    /**
+     * @var Logger
+     */
+    private $logger;
+
+    /**
+     * @param ScopeConfigInterface $scopeConfig
+     * @param ProductFactory $productFactory
+     * @param Logger $logger
+     */
+    public function __construct(
+        ScopeConfigInterface $scopeConfig,
+        ProductFactory $productFactory,
+        Logger $logger
+    ) {
+        $this->scopeConfig = $scopeConfig;
+        $this->productFactory = $productFactory;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Get product TIC (Taxability Information Code) with null safety
+     * Handles cases where product has been deleted or doesn't have custom TIC
+     * 
+     * @param \Magento\Sales\Model\Order\Item $item
+     * @param string $context Context for logging (e.g., 'lookupTaxes', 'returnOrder')
+     * @return string The TIC value
+     */
+    public function getProductTic($item, $context = '')
+    {
+        $product = $item->getProduct();
+        
+        // Handle case where product has been deleted
+        if (!$product || !$product->getId()) {
+            $this->logger->info('Product not found for item ' . $item->getSku() . ' in ' . $context . ', using default TIC');
+            return $this->getDefaultTic();
+        }
+        
+        $productModel = $this->productFactory->create()->load($product->getId());
+        $tic = $productModel->getCustomAttribute('taxcloud_tic');
+        
+        return $tic ? $tic->getValue() : $this->getDefaultTic();
+    }
+
+    /**
+     * Get the default TIC value from configuration
+     * 
+     * @return string
+     */
+    public function getDefaultTic()
+    {
+        return $this->scopeConfig->getValue(
+            'tax/taxcloud_settings/default_tic', 
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        ) ?? '00000';
+    }
+
+    /**
+     * Check if a product exists and is valid
+     * 
+     * @param \Magento\Sales\Model\Order\Item $item
+     * @return bool
+     */
+    public function isProductValid($item)
+    {
+        $product = $item->getProduct();
+        return $product && $product->getId();
+    }
+
+    /**
+     * Get product TIC with additional validation
+     * 
+     * @param \Magento\Sales\Model\Order\Item $item
+     * @param string $context
+     * @return array Array with 'tic' (string) and 'isValid' (boolean)
+     */
+    public function getProductTicWithValidation($item, $context = '')
+    {
+        $isValid = $this->isProductValid($item);
+        $tic = $this->getProductTic($item, $context);
+        
+        return [
+            'tic' => $tic,
+            'isValid' => $isValid
+        ];
+    }
+
+    /**
+     * Get the shipping TIC value from configuration
+     * 
+     * @return string
+     */
+    public function getShippingTic()
+    {
+        return $this->scopeConfig->getValue(
+            'tax/taxcloud_settings/shipping_tic', 
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        ) ?? '11010';
+    }
+}

--- a/Model/ProductTicService.php
+++ b/Model/ProductTicService.php
@@ -60,7 +60,7 @@ class ProductTicService
     /**
      * Get product TIC (Taxability Information Code) with null safety
      * Handles cases where product has been deleted or doesn't have custom TIC
-     * 
+     *
      * @param \Magento\Sales\Model\Order\Item $item
      * @param string $context Context for logging (e.g., 'lookupTaxes', 'returnOrder')
      * @return string The TIC value
@@ -71,7 +71,9 @@ class ProductTicService
         
         // Handle case where product has been deleted
         if (!$product || !$product->getId()) {
-            $this->logger->info('Product not found for item ' . $item->getSku() . ' in ' . $context . ', using default TIC');
+            $this->logger->info(
+                'Product not found for item ' . $item->getSku() . ' in ' . $context . ', using default TIC'
+            );
             return $this->getDefaultTic();
         }
         
@@ -83,20 +85,20 @@ class ProductTicService
 
     /**
      * Get the default TIC value from configuration
-     * 
+     *
      * @return string
      */
     public function getDefaultTic()
     {
         return $this->scopeConfig->getValue(
-            'tax/taxcloud_settings/default_tic', 
+            'tax/taxcloud_settings/default_tic',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         ) ?? '00000';
     }
 
     /**
      * Check if a product exists and is valid
-     * 
+     *
      * @param \Magento\Sales\Model\Order\Item $item
      * @return bool
      */
@@ -108,13 +110,13 @@ class ProductTicService
 
     /**
      * Get the shipping TIC value from configuration
-     * 
+     *
      * @return string
      */
     public function getShippingTic()
     {
         return $this->scopeConfig->getValue(
-            'tax/taxcloud_settings/shipping_tic', 
+            'tax/taxcloud_settings/shipping_tic',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         ) ?? '11010';
     }

--- a/Model/ProductTicService.php
+++ b/Model/ProductTicService.php
@@ -28,6 +28,15 @@ use Taxcloud\Magento2\Logger\Logger;
 class ProductTicService
 {
     /**
+     * Default TIC fallback value when configuration is empty or null
+     */
+    const DEFAULT_TIC = '00000';
+
+    /**
+     * Default shipping TIC fallback value when configuration is empty or null
+     */
+    const DEFAULT_SHIPPING_TIC = '11010';
+    /**
      * @var ScopeConfigInterface
      */
     private $scopeConfig;
@@ -85,6 +94,7 @@ class ProductTicService
 
     /**
      * Get the default TIC value from configuration
+     * Falls back to DEFAULT_TIC if configuration is empty or null
      *
      * @return string
      */
@@ -95,7 +105,7 @@ class ProductTicService
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
         
-        return ($value !== null && $value !== '') ? $value : '00000';
+        return ($value !== null && $value !== '') ? $value : self::DEFAULT_TIC;
     }
 
     /**
@@ -112,6 +122,7 @@ class ProductTicService
 
     /**
      * Get the shipping TIC value from configuration
+     * Falls back to DEFAULT_SHIPPING_TIC if configuration is empty or null
      *
      * @return string
      */
@@ -122,6 +133,6 @@ class ProductTicService
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
         );
         
-        return ($value !== null && $value !== '') ? $value : '11010';
+        return ($value !== null && $value !== '') ? $value : self::DEFAULT_SHIPPING_TIC;
     }
 }

--- a/Model/ProductTicService.php
+++ b/Model/ProductTicService.php
@@ -90,10 +90,12 @@ class ProductTicService
      */
     public function getDefaultTic()
     {
-        return $this->scopeConfig->getValue(
+        $value = $this->scopeConfig->getValue(
             'tax/taxcloud_settings/default_tic',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-        ) ?? '00000';
+        );
+        
+        return ($value !== null && $value !== '') ? $value : '00000';
     }
 
     /**
@@ -115,9 +117,11 @@ class ProductTicService
      */
     public function getShippingTic()
     {
-        return $this->scopeConfig->getValue(
+        $value = $this->scopeConfig->getValue(
             'tax/taxcloud_settings/shipping_tic',
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE
-        ) ?? '11010';
+        );
+        
+        return ($value !== null && $value !== '') ? $value : '11010';
     }
 }

--- a/Model/ProductTicService.php
+++ b/Model/ProductTicService.php
@@ -107,24 +107,6 @@ class ProductTicService
     }
 
     /**
-     * Get product TIC with additional validation
-     * 
-     * @param \Magento\Sales\Model\Order\Item $item
-     * @param string $context
-     * @return array Array with 'tic' (string) and 'isValid' (boolean)
-     */
-    public function getProductTicWithValidation($item, $context = '')
-    {
-        $isValid = $this->isProductValid($item);
-        $tic = $this->getProductTic($item, $context);
-        
-        return [
-            'tic' => $tic,
-            'isValid' => $isValid
-        ];
-    }
-
-    /**
      * Get the shipping TIC value from configuration
      * 
      * @return string

--- a/Test/Unit/Mocks/MagentoMocks.php
+++ b/Test/Unit/Mocks/MagentoMocks.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Minimal Magento Class Definitions for Unit Testing
+ * 
+ * This file provides minimal class definitions needed for PHPUnit mocking
+ * without requiring a full Magento installation.
+ */
+
+namespace Magento\Framework\App\Config {
+    // Prevent the real registration.php from being loaded
+    if (!defined('MAGENTO_MOCKS_LOADED')) {
+        define('MAGENTO_MOCKS_LOADED', true);
+    }
+    interface ScopeConfigInterface
+    {
+        public function getValue($path, $scopeType = null, $scopeCode = null);
+    }
+}
+
+namespace Magento\Store\Model {
+    class ScopeInterface
+    {
+        const SCOPE_STORE = 'store';
+        const SCOPE_WEBSITE = 'website';
+        const SCOPE_GROUP = 'group';
+    }
+}
+
+// Mock Magento Catalog Classes
+namespace Magento\Catalog\Model {
+    class ProductFactory
+    {
+        public function create() { return new Product(); }
+    }
+
+    class Product
+    {
+        public function getId() { return null; }
+        public function setId($id) { return $this; }
+        public function load($id) { return $this; }
+        public function getCustomAttribute($code) { return null; }
+        public function setCustomAttribute($code, $value) { return $this; }
+    }
+}
+
+// Mock Magento Sales Classes
+namespace Magento\Sales\Model\Order {
+    class Item
+    {
+        public function getSku() { return null; }
+        public function setSku($sku) { return $this; }
+        public function getProduct() { return null; }
+        public function setProduct($product) { return $this; }
+    }
+
+    class Order
+    {
+        public function getIncrementId() { return null; }
+        public function setIncrementId($id) { return $this; }
+        public function getAllItems() { return []; }
+        public function setItems($items) { return $this; }
+    }
+
+    class Creditmemo
+    {
+        public function getOrder() { return null; }
+        public function setOrder($order) { return $this; }
+        public function getAllItems() { return []; }
+        public function setItems($items) { return $this; }
+        public function getShippingAmount() { return 0; }
+        public function setShippingAmount($amount) { return $this; }
+    }
+}
+
+namespace Magento\Sales\Model\Order\Creditmemo {
+    class Item
+    {
+        public function getOrderItem() { return null; }
+        public function setOrderItem($item) { return $this; }
+        public function getPrice() { return 0; }
+        public function setPrice($price) { return $this; }
+        public function getDiscountAmount() { return 0; }
+        public function setDiscountAmount($amount) { return $this; }
+        public function getQty() { return 0; }
+        public function setQty($qty) { return $this; }
+    }
+}
+
+// Mock Magento Framework API Classes
+namespace Magento\Framework\Api {
+    class AttributeValue
+    {
+        public function getValue() { return null; }
+        public function setValue($value) { return $this; }
+    }
+}
+
+// Mock Magento Framework Component Registrar (prevents registration.php errors)
+namespace Magento\Framework\Component {
+    class ComponentRegistrar
+    {
+        const MODULE = 'module';
+        const LIBRARY = 'library';
+        const THEME = 'theme';
+        const LANGUAGE = 'language';
+        
+        public static function register($type, $componentName, $path) { /* do nothing */ }
+    }
+}
+
+// Mock Magento Framework Classes
+namespace Magento\Framework {
+    class DataObject
+    {
+        public function getData($key = null) { return null; }
+        public function setData($key, $value = null) { return $this; }
+    }
+
+    class DataObjectFactory
+    {
+        public function create(array $data = []) { return new DataObject(); }
+    }
+}
+
+namespace Magento\Framework\App {
+    class ObjectManager
+    {
+        public static function getInstance() { return new self(); }
+        public function get($type) { return null; }
+    }
+}
+
+// Mock Magento Framework Exception Classes
+namespace Magento\Framework\Exception {
+    class LocalizedException extends \Exception { }
+    class NoSuchEntityException extends \Exception { }
+}
+
+// Mock Magento Framework Event Classes
+namespace Magento\Framework\Event {
+    interface ManagerInterface
+    {
+        public function dispatch($eventName, array $data = []);
+    }
+    
+    class Manager implements ManagerInterface
+    {
+        public function dispatch($eventName, array $data = []) { /* do nothing */ }
+    }
+}
+
+// Mock Magento Framework Cache Classes
+namespace Magento\Framework\App {
+    interface CacheInterface
+    {
+        public function load($identifier);
+        public function save($data, $identifier, $tags = [], $lifeTime = null);
+        public function remove($identifier);
+        public function clean($tags = []);
+    }
+    
+    class Cache implements CacheInterface
+    {
+        public function load($identifier) { return false; }
+        public function save($data, $identifier, $tags = [], $lifeTime = null) { return true; }
+        public function remove($identifier) { return true; }
+        public function clean($tags = []) { return true; }
+    }
+}
+
+// Mock Magento Framework Serializer Classes
+namespace Magento\Framework\Serialize {
+    interface SerializerInterface
+    {
+        public function serialize($data);
+        public function unserialize($string);
+    }
+}
+
+namespace Magento\Framework\Serialize\Serializer {
+    class Json implements \Magento\Framework\Serialize\SerializerInterface
+    {
+        public function serialize($data) { return json_encode($data); }
+        public function unserialize($string) { return json_decode($string, true); }
+    }
+}
+
+// Mock Magento Directory Classes
+namespace Magento\Directory\Model {
+    class RegionFactory
+    {
+        public function create() { return new Region(); }
+    }
+    
+    class Region
+    {
+        public function getId() { return null; }
+        public function setId($id) { return $this; }
+        public function getCode() { return null; }
+        public function setCode($code) { return $this; }
+        public function getName() { return null; }
+        public function setName($name) { return $this; }
+        public function load($id) { return $this; }
+    }
+}
+
+// Mock Magento Framework WebAPI Classes
+namespace Magento\Framework\Webapi\Soap {
+    class ClientFactory
+    {
+        public function create($wsdl, $options = []) { return new Client($wsdl, $options); }
+    }
+    
+    class Client
+    {
+        public function __construct($wsdl, $options = []) { /* do nothing */ }
+        public function __call($method, $args) { return new \stdClass(); }
+    }
+}
+
+// Mock SOAP Classes
+namespace {
+    if (!class_exists('SoapClient')) {
+        class SoapClient
+        {
+            public function __construct($wsdl, $options = []) { /* do nothing */ }
+            public function __call($method, $args) { return new \stdClass(); }
+        }
+    }
+
+    if (!class_exists('SoapFault')) {
+        class SoapFault extends \Exception
+        {
+            public function __construct($faultcode, $faultstring, $faultactor = null, $detail = null, $faultname = null, $headerfault = null)
+            {
+                parent::__construct($faultstring, 0);
+            }
+        }
+    }
+}
+
+// Mock TaxCloud Logger
+namespace Taxcloud\Magento2\Logger {
+    class Logger
+    {
+        public function info($message) { /* do nothing */ }
+        public function error($message) { /* do nothing */ }
+        public function debug($message) { /* do nothing */ }
+    }
+}

--- a/Test/Unit/Mocks/MagentoMocks.php
+++ b/Test/Unit/Mocks/MagentoMocks.php
@@ -6,6 +6,7 @@
  * without requiring a full Magento installation.
  * 
  * HOW TO GENERATE THESE MOCKS:
+ * (Asking AI to generate the mocks for the classes that are not found works pretty well)
  * 
  * 1. When you get "Class not found" errors during unit testing:
  *    - Add the missing class to the appropriate namespace below

--- a/Test/Unit/Mocks/MagentoMocks.php
+++ b/Test/Unit/Mocks/MagentoMocks.php
@@ -4,6 +4,23 @@
  * 
  * This file provides minimal class definitions needed for PHPUnit mocking
  * without requiring a full Magento installation.
+ * 
+ * HOW TO GENERATE THESE MOCKS:
+ * 
+ * 1. When you get "Class not found" errors during unit testing:
+ *    - Add the missing class to the appropriate namespace below
+ *    - Include only the methods that are actually called in your tests
+ *    - Use empty method bodies: public function methodName() {}
+ * 
+ * 2. For interfaces, just declare them without implementation
+ * 3. For classes, add minimal method signatures that your tests need
+ * 4. Keep it minimal - only add what's necessary for tests to run
+ * 
+ * Example:
+ *    class MyClass {
+ *        public function getValue() {}
+ *        public function setValue($value) { return $this; }
+ *    }
  */
 
 namespace Magento\Framework\App\Config {

--- a/Test/Unit/Model/ApiTest.php
+++ b/Test/Unit/Model/ApiTest.php
@@ -29,6 +29,8 @@ use Magento\Directory\Model\RegionFactory;
 use Taxcloud\Magento2\Logger\Logger;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\DataObject;
+use Taxcloud\Magento2\Model\CartItemResponseHandler;
+use Taxcloud\Magento2\Model\ProductTicService;
 
 class ApiTest extends TestCase
 {
@@ -42,6 +44,8 @@ class ApiTest extends TestCase
     private $regionFactory;
     private $logger;
     private $serializer;
+    private $cartItemResponseHandler;
+    private $productTicService;
     private $mockSoapClient;
     private $mockDataObject;
 
@@ -56,8 +60,16 @@ class ApiTest extends TestCase
         $this->regionFactory = $this->createMock(RegionFactory::class);
         $this->logger = $this->createMock(Logger::class);
         $this->serializer = $this->createMock(SerializerInterface::class);
-        $this->mockSoapClient = $this->createMock(\SoapClient::class);
-        $this->mockDataObject = $this->createMock(DataObject::class);
+        $this->cartItemResponseHandler = $this->createMock(CartItemResponseHandler::class);
+        $this->productTicService = $this->createMock(ProductTicService::class);
+        $this->mockSoapClient = $this->getMockBuilder(\SoapClient::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['Returned'])
+            ->getMock();
+        $this->mockDataObject = $this->getMockBuilder(DataObject::class)
+            ->disableOriginalConstructor()
+            ->addMethods(['setParams', 'getParams', 'setResult', 'getResult'])
+            ->getMock();
 
         $this->api = new Api(
             $this->scopeConfig,
@@ -68,7 +80,9 @@ class ApiTest extends TestCase
             $this->productFactory,
             $this->regionFactory,
             $this->logger,
-            $this->serializer
+            $this->serializer,
+            $this->cartItemResponseHandler,
+            $this->productTicService
         );
     }
 
@@ -95,7 +109,7 @@ class ApiTest extends TestCase
 
         // Mock credit memo
         $creditmemo = $this->createMock(\Magento\Sales\Model\Order\Creditmemo::class);
-        $order = $this->createMock(\Magento\Sales\Model\Order::class);
+        $order = $this->createMock(\Magento\Sales\Model\Order\Order::class);
         $order->method('getIncrementId')->willReturn('TEST_ORDER_123');
         
         $creditmemo->method('getOrder')->willReturn($order);
@@ -157,7 +171,7 @@ class ApiTest extends TestCase
 
         // Mock credit memo
         $creditmemo = $this->createMock(\Magento\Sales\Model\Order\Creditmemo::class);
-        $order = $this->createMock(\Magento\Sales\Model\Order::class);
+        $order = $this->createMock(\Magento\Sales\Model\Order\Order::class);
         $order->method('getIncrementId')->willReturn('TEST_ORDER_123');
         
         $creditmemo->method('getOrder')->willReturn($order);
@@ -209,7 +223,7 @@ class ApiTest extends TestCase
 
         // Mock credit memo with items
         $creditmemo = $this->createMock(\Magento\Sales\Model\Order\Creditmemo::class);
-        $order = $this->createMock(\Magento\Sales\Model\Order::class);
+        $order = $this->createMock(\Magento\Sales\Model\Order\Order::class);
         $order->method('getIncrementId')->willReturn('TEST_ORDER_123');
         
         $creditItem = $this->createMock(\Magento\Sales\Model\Order\Creditmemo\Item::class);
@@ -312,7 +326,7 @@ class ApiTest extends TestCase
 
         // Mock credit memo
         $creditmemo = $this->createMock(\Magento\Sales\Model\Order\Creditmemo::class);
-        $order = $this->createMock(\Magento\Sales\Model\Order::class);
+        $order = $this->createMock(\Magento\Sales\Model\Order\Order::class);
         $order->method('getIncrementId')->willReturn('TEST_ORDER_123');
         
         $creditmemo->method('getOrder')->willReturn($order);

--- a/Test/Unit/Model/ProductTicServiceTest.php
+++ b/Test/Unit/Model/ProductTicServiceTest.php
@@ -177,119 +177,84 @@ class ProductTicServiceTest extends TestCase
     }
 
     /**
-     * Test getDefaultTic with configured value
+     * Test getDefaultTic with various configurations
+     * @dataProvider defaultTicProvider
      */
-    public function testGetDefaultTicWithConfiguredValue()
+    public function testGetDefaultTic($configValue, $expectedResult, $description)
     {
         $this->scopeConfig->method('getValue')
             ->with('tax/taxcloud_settings/default_tic', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
-            ->willReturn('12345');
-
-        // Execute the method
-        $result = $this->productTicService->getDefaultTic();
-
-        $this->assertEquals('12345', $result, 'Should return configured default TIC value');
-    }
-
-    /**
-     * Test getDefaultTic with null configuration (fallback)
-     */
-    public function testGetDefaultTicWithNullConfiguration()
-    {
-        $this->scopeConfig->method('getValue')
-            ->with('tax/taxcloud_settings/default_tic', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
-            ->willReturn(null);
+            ->willReturn($configValue);
 
         $result = $this->productTicService->getDefaultTic();
 
-        $this->assertEquals('00000', $result, 'Should return fallback default TIC value when configuration is null');
+        $this->assertEquals($expectedResult, $result, $description);
+    }
+
+    public function defaultTicProvider()
+    {
+        return [
+            'configured value' => ['12345', '12345', 'Should return configured default TIC value'],
+            'null configuration' => [null, '00000', 'Should return fallback default TIC value when configuration is null'],
+            'empty string' => ['', '00000', 'Should return fallback default TIC value when configuration is empty'],
+            'zero value' => ['0', '0', 'Should return zero if configured as zero'],
+        ];
     }
 
     /**
-     * Test isProductValid with valid product
+     * Test isProductValid with various product states
+     * @dataProvider productValidationProvider
      */
-    public function testIsProductValidWithValidProduct()
+    public function testIsProductValid($productId, $expectedResult, $description)
     {
         $item = $this->createMock(Item::class);
-        $product = $this->createMock(Product::class);
         
-        $item->method('getProduct')->willReturn($product);
-        $product->method('getId')->willReturn(789);
+        if ($productId === 'null_product') {
+            $item->method('getProduct')->willReturn(null);
+        } else {
+            $product = $this->createMock(Product::class);
+            $item->method('getProduct')->willReturn($product);
+            $product->method('getId')->willReturn($productId);
+        }
 
         $result = $this->productTicService->isProductValid($item);
 
-        $this->assertTrue($result, 'Should return true for valid product with ID');
+        $this->assertEquals($expectedResult, $result, $description);
     }
 
-    /**
-     * Test isProductValid with null product
-     */
-    public function testIsProductValidWithNullProduct()
+    public function productValidationProvider()
     {
-        $item = $this->createMock(Item::class);
-        $item->method('getProduct')->willReturn(null);
-
-        $result = $this->productTicService->isProductValid($item);
-
-        $this->assertFalse($result, 'Should return false for null product');
+        return [
+            'valid product with ID' => [789, true, 'Should return true for valid product with ID'],
+            'null product' => ['null_product', false, 'Should return false for null product'],
+            'product with no ID' => [null, false, 'Should return false for product with no ID'],
+            'product with zero ID' => [0, false, 'Should return false for product with zero ID'],
+        ];
     }
 
     /**
-     * Test isProductValid with product having no ID
+     * Test getShippingTic with various configurations
+     * @dataProvider shippingTicProvider
      */
-    public function testIsProductValidWithProductHavingNoId()
-    {
-        $item = $this->createMock(Item::class);
-        $product = $this->createMock(Product::class);
-        
-        $item->method('getProduct')->willReturn($product);
-        $product->method('getId')->willReturn(null);
-
-        $result = $this->productTicService->isProductValid($item);
-
-        $this->assertFalse($result, 'Should return false for product with no ID');
-    }
-
-    /**
-     * Test getShippingTic with configured value
-     */
-    public function testGetShippingTicWithConfiguredValue()
+    public function testGetShippingTic($configValue, $expectedResult, $description)
     {
         $this->scopeConfig->method('getValue')
             ->with('tax/taxcloud_settings/shipping_tic', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
-            ->willReturn('11010');
+            ->willReturn($configValue);
 
         $result = $this->productTicService->getShippingTic();
 
-        $this->assertEquals('11010', $result, 'Should return configured shipping TIC value');
+        $this->assertEquals($expectedResult, $result, $description);
     }
 
-    /**
-     * Test getShippingTic with null configuration (fallback)
-     */
-    public function testGetShippingTicWithNullConfiguration()
+    public function shippingTicProvider()
     {
-        $this->scopeConfig->method('getValue')
-            ->with('tax/taxcloud_settings/shipping_tic', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
-            ->willReturn(null);
-
-        $result = $this->productTicService->getShippingTic();
-
-        $this->assertEquals('11010', $result, 'Should return fallback shipping TIC value when configuration is null');
-    }
-
-    /**
-     * Test getShippingTic with custom configured value
-     */
-    public function testGetShippingTicWithCustomConfiguredValue()
-    {
-        $this->scopeConfig->method('getValue')
-            ->with('tax/taxcloud_settings/shipping_tic', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
-            ->willReturn('99999');
-
-        $result = $this->productTicService->getShippingTic();
-
-        $this->assertEquals('99999', $result, 'Should return custom configured shipping TIC value');
+        return [
+            'default configured value' => ['11010', '11010', 'Should return configured shipping TIC value'],
+            'null configuration' => [null, '11010', 'Should return fallback shipping TIC value when configuration is null'],
+            'custom configured value' => ['99999', '99999', 'Should return custom configured shipping TIC value'],
+            'empty string' => ['', '11010', 'Should return fallback shipping TIC value when configuration is empty'],
+        ];
     }
 
 }

--- a/Test/Unit/Model/ProductTicServiceTest.php
+++ b/Test/Unit/Model/ProductTicServiceTest.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * Taxcloud_Magento2
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @package    Taxcloud_Magento2
+ * @author     TaxCloud <service@taxcloud.net>
+ * @copyright  2021 The Federal Tax Authority, LLC d/b/a TaxCloud
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+namespace Taxcloud\Magento2\Test\Unit\Model;
+
+// Load Magento mocks before any other includes
+require_once __DIR__ . '/../Mocks/MagentoMocks.php';
+
+// Load the ProductTicService class directly
+require_once __DIR__ . '/../../../Model/ProductTicService.php';
+
+use PHPUnit\Framework\TestCase;
+use Taxcloud\Magento2\Model\ProductTicService;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Catalog\Model\ProductFactory;
+use Magento\Catalog\Model\Product;
+use Magento\Sales\Model\Order\Item;
+use Magento\Framework\Api\AttributeValue;
+use Taxcloud\Magento2\Logger\Logger;
+
+class ProductTicServiceTest extends TestCase
+{
+    private $productTicService;
+    private $scopeConfig;
+    private $productFactory;
+    private $logger;
+
+    protected function setUp(): void
+    {
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $this->productFactory = $this->createMock(ProductFactory::class);
+        $this->logger = $this->createMock(Logger::class);
+
+        $this->productTicService = new ProductTicService(
+            $this->scopeConfig,
+            $this->productFactory,
+            $this->logger
+        );
+    }
+
+    /**
+     * Test getProductTic with valid product having custom TIC
+     */
+    public function testGetProductTicWithValidProductAndCustomTic()
+    {
+        $item = $this->createMock(Item::class);
+        $product = $this->createMock(Product::class);
+        $productModel = $this->createMock(Product::class);
+        $customAttribute = $this->createMock(AttributeValue::class);
+
+        $item->method('getSku')->willReturn('TEST_SKU');
+        $item->method('getProduct')->willReturn($product);
+
+        $product->method('getId')->willReturn(123);
+
+        $productModel->method('load')->with(123)->willReturnSelf();
+        $productModel->method('getCustomAttribute')->with('taxcloud_tic')->willReturn($customAttribute);
+
+        $customAttribute->method('getValue')->willReturn('20000');
+
+        $this->productFactory->method('create')->willReturn($productModel);
+
+        $result = $this->productTicService->getProductTic($item, 'testContext');
+
+        $this->assertEquals('20000', $result, 'Should return custom TIC value when product has custom TIC');
+    }
+
+    /**
+     * Test getProductTic with deleted/null product
+     */
+    public function testGetProductTicWithDeletedProduct()
+    {
+        $item = $this->createMock(Item::class);
+        $item->method('getSku')->willReturn('DELETED_SKU');
+        $item->method('getProduct')->willReturn(null);
+
+        $this->scopeConfig->method('getValue')
+            ->with('tax/taxcloud_settings/default_tic', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+            ->willReturn('00000');
+
+        $this->logger->expects($this->once())
+            ->method('info')
+            ->with('Product not found for item DELETED_SKU in testContext, using default TIC');
+
+        $result = $this->productTicService->getProductTic($item, 'testContext');
+
+        $this->assertEquals('00000', $result, 'Should return default TIC when product is null');
+    }
+
+    /**
+     * Test getProductTic with product having no ID
+     */
+    public function testGetProductTicWithProductHavingNoId()
+    {
+        $item = $this->createMock(Item::class);
+        $product = $this->createMock(Product::class);
+        
+        $item->method('getSku')->willReturn('NO_ID_SKU');
+        $item->method('getProduct')->willReturn($product);
+        $product->method('getId')->willReturn(null);
+
+        $this->scopeConfig->method('getValue')
+            ->with('tax/taxcloud_settings/default_tic', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+            ->willReturn('00000');
+
+        $this->logger->expects($this->once())
+            ->method('info')
+            ->with('Product not found for item NO_ID_SKU in testContext, using default TIC');
+
+        $result = $this->productTicService->getProductTic($item, 'testContext');
+
+        $this->assertEquals('00000', $result, 'Should return default TIC when product has no ID');
+    }
+
+    /**
+     * Test getProductTic with product having no custom TIC attribute
+     */
+    public function testGetProductTicWithNoCustomTicAttribute()
+    {
+        $item = $this->createMock(Item::class);
+        $product = $this->createMock(Product::class);
+        $productModel = $this->createMock(Product::class);
+
+        $item->method('getSku')->willReturn('NO_TIC_SKU');
+        $item->method('getProduct')->willReturn($product);
+
+        $product->method('getId')->willReturn(456);
+
+        $productModel->method('load')->with(456)->willReturnSelf();
+        $productModel->method('getCustomAttribute')->with('taxcloud_tic')->willReturn(null);
+
+        $this->productFactory->method('create')->willReturn($productModel);
+
+        $this->scopeConfig->method('getValue')
+            ->with('tax/taxcloud_settings/default_tic', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+            ->willReturn('00000');
+
+        $result = $this->productTicService->getProductTic($item, 'testContext');
+
+        $this->assertEquals('00000', $result, 'Should return default TIC when product has no custom TIC attribute');
+    }
+
+    /**
+     * Test getProductTic with empty context parameter
+     */
+    public function testGetProductTicWithEmptyContext()
+    {
+        $item = $this->createMock(Item::class);
+        $item->method('getSku')->willReturn('TEST_SKU');
+        $item->method('getProduct')->willReturn(null);
+
+        $this->scopeConfig->method('getValue')
+            ->with('tax/taxcloud_settings/default_tic', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+            ->willReturn('00000');
+
+        $this->logger->expects($this->once())
+            ->method('info')
+            ->with('Product not found for item TEST_SKU in , using default TIC');
+
+        $result = $this->productTicService->getProductTic($item, '');
+
+        $this->assertEquals('00000', $result, 'Should return default TIC when context is empty');
+    }
+
+    /**
+     * Test getDefaultTic with configured value
+     */
+    public function testGetDefaultTicWithConfiguredValue()
+    {
+        $this->scopeConfig->method('getValue')
+            ->with('tax/taxcloud_settings/default_tic', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+            ->willReturn('12345');
+
+        // Execute the method
+        $result = $this->productTicService->getDefaultTic();
+
+        $this->assertEquals('12345', $result, 'Should return configured default TIC value');
+    }
+
+    /**
+     * Test getDefaultTic with null configuration (fallback)
+     */
+    public function testGetDefaultTicWithNullConfiguration()
+    {
+        $this->scopeConfig->method('getValue')
+            ->with('tax/taxcloud_settings/default_tic', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+            ->willReturn(null);
+
+        $result = $this->productTicService->getDefaultTic();
+
+        $this->assertEquals('00000', $result, 'Should return fallback default TIC value when configuration is null');
+    }
+
+    /**
+     * Test isProductValid with valid product
+     */
+    public function testIsProductValidWithValidProduct()
+    {
+        $item = $this->createMock(Item::class);
+        $product = $this->createMock(Product::class);
+        
+        $item->method('getProduct')->willReturn($product);
+        $product->method('getId')->willReturn(789);
+
+        $result = $this->productTicService->isProductValid($item);
+
+        $this->assertTrue($result, 'Should return true for valid product with ID');
+    }
+
+    /**
+     * Test isProductValid with null product
+     */
+    public function testIsProductValidWithNullProduct()
+    {
+        $item = $this->createMock(Item::class);
+        $item->method('getProduct')->willReturn(null);
+
+        $result = $this->productTicService->isProductValid($item);
+
+        $this->assertFalse($result, 'Should return false for null product');
+    }
+
+    /**
+     * Test isProductValid with product having no ID
+     */
+    public function testIsProductValidWithProductHavingNoId()
+    {
+        $item = $this->createMock(Item::class);
+        $product = $this->createMock(Product::class);
+        
+        $item->method('getProduct')->willReturn($product);
+        $product->method('getId')->willReturn(null);
+
+        $result = $this->productTicService->isProductValid($item);
+
+        $this->assertFalse($result, 'Should return false for product with no ID');
+    }
+
+    /**
+     * Test getShippingTic with configured value
+     */
+    public function testGetShippingTicWithConfiguredValue()
+    {
+        $this->scopeConfig->method('getValue')
+            ->with('tax/taxcloud_settings/shipping_tic', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+            ->willReturn('11010');
+
+        $result = $this->productTicService->getShippingTic();
+
+        $this->assertEquals('11010', $result, 'Should return configured shipping TIC value');
+    }
+
+    /**
+     * Test getShippingTic with null configuration (fallback)
+     */
+    public function testGetShippingTicWithNullConfiguration()
+    {
+        $this->scopeConfig->method('getValue')
+            ->with('tax/taxcloud_settings/shipping_tic', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+            ->willReturn(null);
+
+        $result = $this->productTicService->getShippingTic();
+
+        $this->assertEquals('11010', $result, 'Should return fallback shipping TIC value when configuration is null');
+    }
+
+    /**
+     * Test getShippingTic with custom configured value
+     */
+    public function testGetShippingTicWithCustomConfiguredValue()
+    {
+        $this->scopeConfig->method('getValue')
+            ->with('tax/taxcloud_settings/shipping_tic', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
+            ->willReturn('99999');
+
+        $result = $this->productTicService->getShippingTic();
+
+        $this->assertEquals('99999', $result, 'Should return custom configured shipping TIC value');
+    }
+
+}

--- a/Test/Unit/bootstrap.php
+++ b/Test/Unit/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Bootstrap file for unit tests
+ * This file loads the Magento mocks before any other classes
+ */
+
+// Load Magento mocks first to prevent registration.php errors
+require_once __DIR__ . '/Mocks/MagentoMocks.php';
+
+// Now it's safe to load the autoloader
+require_once __DIR__ . '/../../vendor/autoload.php';

--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
   "version": "1.0.0",
   "license": "OSL-3.0",
   "autoload": {
-    "files": [
-      "registration.php"
-    ],
     "psr-4": {
       "Taxcloud\\Magento2\\": ""
     }
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^9.5"
   }
 }


### PR DESCRIPTION
Addresses DEV-5858
Use default tics for deleted products
Testing for product tics service
fixes api service tests

Also creates a set of Magento mocks that we can bootstrap over the paths that typically go to the full magento framework. Since this is an extension we aren't able to create a whole magento framework environment, but this way we have classes that we can then mock the functionality of. The hope is that the underlying functionality of Magento wouldn't ever change that much, but our tests will fail if we update the main code so.