### PR TITLE
Dev 6704/tax not persisted magento objects

### DIFF
--- a/Model/Tax.php
+++ b/Model/Tax.php
@@ -163,19 +163,15 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
 
                 $productTaxTotal += (float) $taxAmount;
 
-                // Calculate base tax amount (using same value as baseTaxDetail will be set to)
-                $baseTaxAmount = $taxAmount;
-                $baseTaxAmountPer = $baseTaxAmount / $quoteItem->getQty();
-
                 // Persist tax onto quote item so tax does not get lost downstream
                 // This ensures tax is available when quote is converted to order
                 $quoteItem->setTaxAmount($taxAmount);
-                $quoteItem->setBaseTaxAmount($baseTaxAmount);
+                $quoteItem->setBaseTaxAmount($taxAmount);
                 $quoteItem->setTaxPercent($taxDetail->getRowTotal() > 0 ? round(100 * $taxAmount / $taxDetail->getRowTotal(), 2) : 0);
                 $quoteItem->setPriceInclTax($quoteItem->getPrice() + $taxAmountPer);
-                $quoteItem->setBasePriceInclTax($quoteItem->getBasePrice() + $baseTaxAmountPer);
+                $quoteItem->setBasePriceInclTax($quoteItem->getBasePrice() + $taxAmountPer);
                 $quoteItem->setRowTotalInclTax($quoteItem->getRowTotal() + $taxAmount);
-                $quoteItem->setBaseRowTotalInclTax($quoteItem->getBaseRowTotal() + $baseTaxAmount);
+                $quoteItem->setBaseRowTotalInclTax($quoteItem->getBaseRowTotal() + $taxAmount);
 
                 $taxDetail->setRowTax($taxAmount);
                 $taxDetail->setPriceInclTax($taxDetail->getPrice() + $taxAmountPer);

--- a/Model/Tax.php
+++ b/Model/Tax.php
@@ -144,6 +144,8 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
             $keyedAddressItems[$item->getTaxCalculationItemId()] = $item;
         }
 
+        $productTaxTotal = 0.0;
+
         if (isset($itemsByType[self::ITEM_TYPE_PRODUCT])) {
             foreach ($itemsByType[self::ITEM_TYPE_PRODUCT] as $code => $itemTaxDetail) {
                 $taxDetail = $itemTaxDetail[self::KEY_ITEM];
@@ -158,6 +160,22 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
                     $taxAmount = $taxAmounts[self::ITEM_TYPE_PRODUCT][$code] ?? 0;
                     $taxAmountPer = $taxAmount / $quoteItem->getQty();
                 }
+
+                $productTaxTotal += (float) $taxAmount;
+
+                // Calculate base tax amount (using same value as baseTaxDetail will be set to)
+                $baseTaxAmount = $taxAmount;
+                $baseTaxAmountPer = $baseTaxAmount / $quoteItem->getQty();
+
+                // Persist tax onto quote item so tax does not get lost downstream
+                // This ensures tax is available when quote is converted to order
+                $quoteItem->setTaxAmount($taxAmount);
+                $quoteItem->setBaseTaxAmount($baseTaxAmount);
+                $quoteItem->setTaxPercent($taxDetail->getRowTotal() > 0 ? round(100 * $taxAmount / $taxDetail->getRowTotal(), 2) : 0);
+                $quoteItem->setPriceInclTax($quoteItem->getPrice() + $taxAmountPer);
+                $quoteItem->setBasePriceInclTax($quoteItem->getBasePrice() + $baseTaxAmountPer);
+                $quoteItem->setRowTotalInclTax($quoteItem->getRowTotal() + $taxAmount);
+                $quoteItem->setBaseRowTotalInclTax($quoteItem->getBaseRowTotal() + $baseTaxAmount);
 
                 $taxDetail->setRowTax($taxAmount);
                 $taxDetail->setPriceInclTax($taxDetail->getPrice() + $taxAmountPer);
@@ -226,6 +244,24 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
 
         //Save applied taxes for each item and the quote in aggregation
         $this->processAppliedTaxes($total, $shippingAssignment, $itemsByType);
+
+        // Defensive safeguard: if Magento only kept shipping tax in totals, add product tax
+        // This handles cases where processAppliedTaxes() or other Magento processes
+        // might have dropped product tax from the order totals
+        $shippingTaxTotal = (float) ($taxAmounts[self::ITEM_TYPE_SHIPPING] ?? 0);
+        $currentTaxTotal = (float) $total->getTaxAmount();
+        
+        // Check if product tax exists but wasn't included in totals
+        // Compare current total to shipping tax (with small tolerance for rounding)
+        if ($productTaxTotal > 0.0001 && abs($currentTaxTotal - $shippingTaxTotal) < 0.0001) {
+            $this->tclogger->info(
+                sprintf('Product tax missing from totals. Adding %.2f to total tax.', $productTaxTotal)
+            );
+            $total->setTaxAmount($currentTaxTotal + $productTaxTotal);
+            $total->setBaseTaxAmount((float) $total->getBaseTaxAmount() + $productTaxTotal);
+            $total->addTotalAmount('tax', $productTaxTotal);
+            $total->addBaseTotalAmount('tax', $productTaxTotal);
+        }
 
         if ($this->includeExtraTax()) {
             $total->addTotalAmount('extra_tax', $total->getExtraTaxAmount());

--- a/Test/Unit/Mocks/MagentoMocks.php
+++ b/Test/Unit/Mocks/MagentoMocks.php
@@ -58,6 +58,7 @@ namespace Magento\Catalog\Model {
         public function load($id) { return $this; }
         public function getCustomAttribute($code) { return null; }
         public function setCustomAttribute($code, $value) { return $this; }
+        public function getTaxClassId() { return null; }
     }
 }
 
@@ -264,5 +265,138 @@ namespace Taxcloud\Magento2\Logger {
         public function info($message) { /* do nothing */ }
         public function error($message) { /* do nothing */ }
         public function debug($message) { /* do nothing */ }
+    }
+}
+
+// Mock Magento Quote Classes
+namespace Magento\Quote\Model {
+    class Quote
+    {
+        public function getCustomerTaxClassId() { return null; }
+        public function getStoreId() { return 1; }
+    }
+}
+
+namespace Magento\Quote\Model\Quote {
+    class Item
+    {
+        public function getTaxCalculationItemId() { return null; }
+        public function getProduct() { return null; }
+        public function getQty() { return 1; }
+        public function getPrice() { return 0; }
+        public function getBasePrice() { return 0; }
+        public function getRowTotal() { return 0; }
+        public function getBaseRowTotal() { return 0; }
+        public function setTaxAmount($amount) { return $this; }
+        public function setBaseTaxAmount($amount) { return $this; }
+        public function setTaxPercent($percent) { return $this; }
+        public function setPriceInclTax($price) { return $this; }
+        public function setBasePriceInclTax($price) { return $this; }
+        public function setRowTotalInclTax($total) { return $this; }
+        public function setBaseRowTotalInclTax($total) { return $this; }
+    }
+}
+
+namespace Magento\Quote\Model\Quote\Address {
+    class Total
+    {
+        public function getTaxAmount() { return 0; }
+        public function getBaseTaxAmount() { return 0; }
+        public function setTaxAmount($amount) { return $this; }
+        public function setBaseTaxAmount($amount) { return $this; }
+        public function addTotalAmount($code, $amount) { return $this; }
+        public function addBaseTotalAmount($code, $amount) { return $this; }
+    }
+}
+
+namespace Magento\Quote\Api\Data {
+    interface ShippingAssignmentInterface
+    {
+        public function getItems();
+    }
+}
+
+// Mock Magento Tax Classes
+namespace Magento\Tax\Model {
+    class Config
+    {
+        public function priceIncludesTax() { return false; }
+    }
+}
+
+namespace Magento\Tax\Model\Sales\Total\Quote {
+    class Tax
+    {
+        const ITEM_TYPE_SHIPPING = 'shipping';
+        const ITEM_TYPE_PRODUCT = 'product';
+        const ITEM_CODE_SHIPPING = 'shipping';
+        const KEY_ITEM = 'item';
+        const KEY_BASE_ITEM = 'base_item';
+        
+        protected function clearValues($total) { /* do nothing */ }
+        protected function getQuoteTaxDetails($shippingAssignment, $total, $base) { return null; }
+        protected function organizeItemTaxDetailsByType($taxDetails, $baseTaxDetails) { return []; }
+        protected function processProductItems($shippingAssignment, $items, $total) { /* do nothing */ }
+        protected function processShippingTaxInfo($shippingAssignment, $total, $shippingTaxDetails, $baseShippingTaxDetails) { /* do nothing */ }
+        protected function processExtraTaxables($total, $itemsByType) { /* do nothing */ }
+        protected function processAppliedTaxes($total, $shippingAssignment, $itemsByType) { /* do nothing */ }
+        protected function includeExtraTax() { return false; }
+    }
+}
+
+namespace Magento\Tax\Api {
+    interface TaxCalculationInterface
+    {
+        public function calculateTax($quoteDetails, $storeId);
+    }
+}
+
+namespace Magento\Tax\Api\Data {
+    interface QuoteDetailsInterface { }
+    interface QuoteDetailsItemInterface
+    {
+        public function getCode();
+        public function getType();
+        public function getRowTax();
+    }
+    interface TaxClassKeyInterface
+    {
+        const TYPE_ID = 'id';
+    }
+}
+
+namespace Magento\Tax\Api\Data {
+    interface QuoteDetailsInterfaceFactory
+    {
+        public function create();
+    }
+    
+    interface QuoteDetailsItemInterfaceFactory
+    {
+        public function create();
+    }
+    
+    interface TaxClassKeyInterfaceFactory
+    {
+        public function create();
+    }
+}
+
+namespace Magento\Customer\Api\Data {
+    interface AddressInterfaceFactory
+    {
+        public function create();
+    }
+    
+    interface RegionInterfaceFactory
+    {
+        public function create();
+    }
+}
+
+namespace Magento\Tax\Helper {
+    class Data
+    {
+        public function getPriceDisplayType() { return 1; }
     }
 }

--- a/Test/Unit/Model/TaxTest.php
+++ b/Test/Unit/Model/TaxTest.php
@@ -1,0 +1,359 @@
+<?php
+/**
+ * Taxcloud_Magento2
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @package    Taxcloud_Magento2
+ * @author     TaxCloud <service@taxcloud.net>
+ * @copyright  2021 The Federal Tax Authority, LLC d/b/a TaxCloud
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+namespace Taxcloud\Magento2\Test\Unit\Model;
+
+// Load Magento mocks before any other includes
+require_once __DIR__ . '/../Mocks/MagentoMocks.php';
+
+// Load the Tax class directly
+require_once __DIR__ . '/../../../Model/Tax.php';
+
+use PHPUnit\Framework\TestCase;
+use Taxcloud\Magento2\Model\Tax;
+use Taxcloud\Magento2\Model\Api as TaxCloudApi;
+use Magento\Tax\Model\Config;
+use Magento\Tax\Api\TaxCalculationInterface;
+use Magento\Tax\Api\Data\QuoteDetailsInterfaceFactory;
+use Magento\Tax\Api\Data\QuoteDetailsItemInterfaceFactory;
+use Magento\Tax\Api\Data\TaxClassKeyInterfaceFactory;
+use Magento\Customer\Api\Data\AddressInterfaceFactory;
+use Magento\Customer\Api\Data\RegionInterfaceFactory;
+use Magento\Tax\Helper\Data;
+use Magento\Framework\Serialize\Serializer\Json;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Taxcloud\Magento2\Logger\Logger;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Api\Data\ShippingAssignmentInterface;
+use Magento\Quote\Model\Quote\Address\Total;
+use Magento\Quote\Model\Quote\Item as QuoteItem;
+use Magento\Catalog\Model\Product;
+
+class TaxTest extends TestCase
+{
+    private $tax;
+    private $scopeConfig;
+    private $taxConfig;
+    private $taxCalculationService;
+    private $quoteDetailsFactory;
+    private $quoteDetailsItemFactory;
+    private $taxClassKeyFactory;
+    private $customerAddressFactory;
+    private $customerAddressRegionFactory;
+    private $taxData;
+    private $serializer;
+    private $tcapi;
+    private $tclogger;
+
+    protected function setUp(): void
+    {
+        $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
+        $this->taxConfig = $this->createMock(Config::class);
+        $this->taxCalculationService = $this->createMock(TaxCalculationInterface::class);
+        $this->quoteDetailsFactory = $this->createMock(QuoteDetailsInterfaceFactory::class);
+        $this->quoteDetailsItemFactory = $this->createMock(QuoteDetailsItemInterfaceFactory::class);
+        $this->taxClassKeyFactory = $this->createMock(TaxClassKeyInterfaceFactory::class);
+        $this->customerAddressFactory = $this->createMock(AddressInterfaceFactory::class);
+        $this->customerAddressRegionFactory = $this->createMock(RegionInterfaceFactory::class);
+        $this->taxData = $this->createMock(Data::class);
+        $this->serializer = $this->createMock(Json::class);
+        $this->tcapi = $this->createMock(TaxCloudApi::class);
+        $this->tclogger = $this->createMock(Logger::class);
+
+        $this->createTaxInstance();
+    }
+
+    /**
+     * Helper: Create Tax instance (can be recreated if needed)
+     */
+    private function createTaxInstance()
+    {
+        // Create Tax instance with disabled constructor to avoid parent class issues
+        $this->tax = $this->getMockBuilder(Tax::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'clearValues',
+                'getQuoteTaxDetails',
+                'organizeItemTaxDetailsByType',
+                'processProductItems',
+                'processShippingTaxInfo',
+                'processExtraTaxables',
+                'processAppliedTaxes',
+                'includeExtraTax'
+            ])
+            ->getMock();
+        
+        // Manually set the properties we need using reflection
+        $reflection = new \ReflectionClass($this->tax);
+        
+        $scopeConfigProperty = $reflection->getProperty('scopeConfig');
+        $scopeConfigProperty->setAccessible(true);
+        $scopeConfigProperty->setValue($this->tax, $this->scopeConfig);
+        
+        $tcapiProperty = $reflection->getProperty('tcapi');
+        $tcapiProperty->setAccessible(true);
+        $tcapiProperty->setValue($this->tax, $this->tcapi);
+        
+        $tcloggerProperty = $reflection->getProperty('tclogger');
+        $tcloggerProperty->setAccessible(true);
+        $tcloggerProperty->setValue($this->tax, $this->tclogger);
+    }
+
+    /**
+     * Helper: Configure TaxCloud as enabled
+     */
+    private function configureTaxCloudEnabled($logging = false)
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                ['tax/taxcloud_settings/enabled', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null, '1'],
+                ['tax/taxcloud_settings/logging', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null, $logging ? '1' : '0']
+            ]);
+        
+        // Set logger based on logging setting
+        // In real code, Tax constructor checks config, but we bypass that with disabled constructor
+        $reflection = new \ReflectionClass($this->tax);
+        $tcloggerProperty = $reflection->getProperty('tclogger');
+        $tcloggerProperty->setAccessible(true);
+        // Always use mock logger so we can verify calls in tests
+        $tcloggerProperty->setValue($this->tax, $this->tclogger);
+    }
+
+    /**
+     * Helper: Create a mock quote
+     */
+    private function createMockQuote($customerTaxClassId = '3', $storeId = 1)
+    {
+        $quote = $this->createMock(Quote::class);
+        $quote->method('getCustomerTaxClassId')->willReturn($customerTaxClassId);
+        $quote->method('getStoreId')->willReturn($storeId);
+        return $quote;
+    }
+
+    /**
+     * Helper: Create a mock quote item
+     */
+    private function createMockQuoteItem($itemId = 'item-1', $qty = 1, $price = 50.00, $rowTotal = null, $taxClassId = '2')
+    {
+        $rowTotal = $rowTotal ?? ($price * $qty);
+        
+        $quoteItem = $this->getMockBuilder(QuoteItem::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getTaxCalculationItemId', 'getProduct', 'getQty', 'getPrice', 'getBasePrice', 'getRowTotal', 'getBaseRowTotal', 'setTaxAmount', 'setBaseTaxAmount', 'setTaxPercent', 'setPriceInclTax', 'setBasePriceInclTax', 'setRowTotalInclTax', 'setBaseRowTotalInclTax'])
+            ->getMock();
+        
+        $product = $this->createMock(Product::class);
+        $product->method('getTaxClassId')->willReturn($taxClassId);
+        
+        $quoteItem->method('getTaxCalculationItemId')->willReturn($itemId);
+        $quoteItem->method('getProduct')->willReturn($product);
+        $quoteItem->method('getQty')->willReturn($qty);
+        $quoteItem->method('getPrice')->willReturn($price);
+        $quoteItem->method('getBasePrice')->willReturn($price);
+        $quoteItem->method('getRowTotal')->willReturn($rowTotal);
+        $quoteItem->method('getBaseRowTotal')->willReturn($rowTotal);
+        
+        return $quoteItem;
+    }
+
+    /**
+     * Helper: Create mock tax detail objects
+     */
+    private function createMockTaxDetails($price = 50.00, $rowTotal = 100.00)
+    {
+        $taxDetail = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['getPrice', 'getRowTotal', 'setRowTax', 'setPriceInclTax', 'setRowTotalInclTax', 'setAppliedTaxes', 'setTaxPercent', 'getRowTax'])
+            ->getMock();
+        $taxDetail->method('getPrice')->willReturn($price);
+        $taxDetail->method('getRowTotal')->willReturn($rowTotal);
+        
+        $baseTaxDetail = $this->getMockBuilder(\stdClass::class)
+            ->addMethods(['getPrice', 'getRowTotal', 'setRowTax', 'setPriceInclTax', 'setRowTotalInclTax', 'setAppliedTaxes', 'setTaxPercent', 'getRowTax'])
+            ->getMock();
+        $baseTaxDetail->method('getPrice')->willReturn($price);
+        $baseTaxDetail->method('getRowTotal')->willReturn($rowTotal);
+        
+        return [$taxDetail, $baseTaxDetail];
+    }
+
+    /**
+     * Helper: Setup parent class method mocks
+     */
+    private function setupParentMethodMocks($itemsByType = [])
+    {
+        $this->tax->method('clearValues')->willReturnSelf();
+        $this->tax->method('getQuoteTaxDetails')->willReturn(null);
+        $this->tax->method('organizeItemTaxDetailsByType')->willReturn($itemsByType);
+        $this->tax->method('processProductItems')->willReturnSelf();
+        $this->tax->method('processShippingTaxInfo')->willReturnSelf();
+        $this->tax->method('processExtraTaxables')->willReturnSelf();
+        $this->tax->method('processAppliedTaxes')->willReturnSelf();
+        $this->tax->method('includeExtraTax')->willReturn(false);
+    }
+
+    /**
+     * Helper: Create itemsByType structure for product items
+     */
+    private function createItemsByTypeForProduct($itemId, $taxDetail, $baseTaxDetail)
+    {
+        return [
+            Tax::ITEM_TYPE_PRODUCT => [
+                $itemId => [
+                    Tax::KEY_ITEM => $taxDetail,
+                    Tax::KEY_BASE_ITEM => $baseTaxDetail
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * Helper: Setup TaxCloud API mock
+     */
+    private function setupTaxCloudApiMock($productTax = [], $shippingTax = 0)
+    {
+        $taxAmounts = [
+            Tax::ITEM_TYPE_PRODUCT => $productTax,
+            Tax::ITEM_TYPE_SHIPPING => $shippingTax
+        ];
+        $this->tcapi->method('lookupTaxes')->willReturn($taxAmounts);
+    }
+
+    /**
+     * Helper: Create a complete test scenario
+     */
+    private function createTestScenario($productTaxAmount = 5.00, $shippingTaxAmount = 2.50, $itemPrice = 50.00, $itemQty = 1, $logging = false)
+    {
+        $this->configureTaxCloudEnabled($logging);
+        
+        $quote = $this->createMockQuote();
+        $quoteItem = $this->createMockQuoteItem('item-1', $itemQty, $itemPrice);
+        
+        $shippingAssignment = $this->createMock(ShippingAssignmentInterface::class);
+        $shippingAssignment->method('getItems')->willReturn([$quoteItem]);
+        
+        $total = $this->createMock(Total::class);
+        $total->method('getTaxAmount')->willReturn(0);
+        $total->method('getBaseTaxAmount')->willReturn(0);
+        
+        [$taxDetail, $baseTaxDetail] = $this->createMockTaxDetails($itemPrice, $itemPrice * $itemQty);
+        $itemsByType = $this->createItemsByTypeForProduct('item-1', $taxDetail, $baseTaxDetail);
+        
+        $this->setupParentMethodMocks($itemsByType);
+        $this->setupTaxCloudApiMock(['item-1' => $productTaxAmount], $shippingTaxAmount);
+        
+        return [$quote, $shippingAssignment, $total, $quoteItem];
+    }
+
+    /**
+     * Test that product tax is persisted to quote items
+     */
+    public function testProductTaxIsPersistedToQuoteItems()
+    {
+        [$quote, $shippingAssignment, $total, $quoteItem] = $this->createTestScenario(
+            productTaxAmount: 5.00,
+            shippingTaxAmount: 2.50,
+            itemPrice: 50.00,
+            itemQty: 2
+        );
+
+        // Expect tax to be set on quote item
+        $quoteItem->expects($this->once())
+            ->method('setTaxAmount')
+            ->with($this->equalTo(5.00));
+        
+        $quoteItem->expects($this->once())
+            ->method('setBaseTaxAmount')
+            ->with($this->equalTo(5.00));
+        
+        $quoteItem->expects($this->once())
+            ->method('setTaxPercent')
+            ->with($this->equalTo(5.00));
+        
+        $quoteItem->expects($this->once())
+            ->method('setPriceInclTax')
+            ->with($this->equalTo(52.50)); // 50 + (5/2)
+        
+        $quoteItem->expects($this->once())
+            ->method('setBasePriceInclTax')
+            ->with($this->equalTo(52.50));
+        
+        $quoteItem->expects($this->once())
+            ->method('setRowTotalInclTax')
+            ->with($this->equalTo(105.00)); // 100 + 5
+        
+        $quoteItem->expects($this->once())
+            ->method('setBaseRowTotalInclTax')
+            ->with($this->equalTo(105.00));
+
+        // Call collect
+        $result = $this->tax->collect($quote, $shippingAssignment, $total);
+
+        $this->assertSame($this->tax, $result);
+    }
+
+    /**
+     * Test defensive safeguard adds product tax when missing from totals
+     */
+    public function testDefensiveSafeguardAddsProductTaxToTotals()
+    {
+        $this->configureTaxCloudEnabled(logging: true);
+        
+        $quote = $this->createMockQuote();
+        $quoteItem = $this->createMockQuoteItem('item-1', 1, 50.00);
+        
+        $shippingAssignment = $this->createMock(ShippingAssignmentInterface::class);
+        $shippingAssignment->method('getItems')->willReturn([$quoteItem]);
+        
+        // Create mock total - simulate that only shipping tax is present AFTER processAppliedTaxes
+        // The defensive safeguard checks getTaxAmount() AFTER processAppliedTaxes runs
+        $total = $this->createMock(Total::class);
+        // getTaxAmount() is called once in defensive safeguard, should return 2.50 (only shipping tax)
+        $total->method('getTaxAmount')->willReturn(2.50);
+        $total->method('getBaseTaxAmount')->willReturn(2.50);
+        
+        [$taxDetail, $baseTaxDetail] = $this->createMockTaxDetails(50.00, 50.00);
+        $itemsByType = $this->createItemsByTypeForProduct('item-1', $taxDetail, $baseTaxDetail);
+        
+        $this->setupParentMethodMocks($itemsByType);
+        $this->setupTaxCloudApiMock(['item-1' => 5.00], 2.50);
+
+        // Expect defensive safeguard to add product tax
+        $total->expects($this->once())
+            ->method('setTaxAmount')
+            ->with($this->equalTo(7.50)); // 2.50 shipping + 5.00 product
+        
+        $total->expects($this->once())
+            ->method('setBaseTaxAmount')
+            ->with($this->equalTo(7.50));
+        
+        $total->expects($this->once())
+            ->method('addTotalAmount')
+            ->with('tax', 5.00);
+        
+        $total->expects($this->once())
+            ->method('addBaseTotalAmount')
+            ->with('tax', 5.00);
+
+        // Mock logger to verify defensive safeguard message
+        $this->tclogger->expects($this->once())
+            ->method('info')
+            ->with($this->stringContains('Product tax missing from totals'));
+
+        // Call collect
+        $this->tax->collect($quote, $shippingAssignment, $total);
+    }
+}


### PR DESCRIPTION
DEV-6704

- Persists tax info to orders to be stored in magento
- updates our custom mocks for magento objects to be used in tests
- test persisting tax on mock objects