### PR TITLE
DEV-7407 Distribute adjustment-only refunds across remaining items

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -157,6 +157,13 @@ class Api
     private $customerAddressRegionFactory;
 
     /**
+     * Refund Distributor
+     *
+     * @var \Taxcloud\Magento2\Model\RefundDistributor
+     */
+    private $refundDistributor;
+
+    /**
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Magento\Framework\App\CacheInterface $cacheType
      * @param \Magento\Framework\Event\ManagerInterface $eventManager
@@ -174,6 +181,7 @@ class Api
      * @param \Magento\Tax\Api\Data\TaxClassKeyInterfaceFactory $taxClassKeyFactory
      * @param \Magento\Customer\Api\Data\AddressInterfaceFactory $customerAddressFactory
      * @param \Magento\Customer\Api\Data\RegionInterfaceFactory $customerAddressRegionFactory
+     * @param \Taxcloud\Magento2\Model\RefundDistributor $refundDistributor
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -193,7 +201,8 @@ class Api
         \Magento\Tax\Api\Data\QuoteDetailsItemInterfaceFactory $quoteDetailsItemFactory,
         \Magento\Tax\Api\Data\TaxClassKeyInterfaceFactory $taxClassKeyFactory,
         \Magento\Customer\Api\Data\AddressInterfaceFactory $customerAddressFactory,
-        \Magento\Customer\Api\Data\RegionInterfaceFactory $customerAddressRegionFactory
+        \Magento\Customer\Api\Data\RegionInterfaceFactory $customerAddressRegionFactory,
+        \Taxcloud\Magento2\Model\RefundDistributor $refundDistributor
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->cacheType = $cacheType;
@@ -211,6 +220,7 @@ class Api
         $this->taxClassKeyFactory = $taxClassKeyFactory;
         $this->customerAddressFactory = $customerAddressFactory;
         $this->customerAddressRegionFactory = $customerAddressRegionFactory;
+        $this->refundDistributor = $refundDistributor;
         if ($scopeConfig->getValue('tax/taxcloud_settings/logging', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)) {
             $this->tclogger = $tclogger;
         } else {
@@ -858,6 +868,23 @@ class Api
             if ($isTaxOnlyRefund) {
                 $this->tclogger->info('returnOrder: tax-only refund detected; will re-create as exempt after Returned');
                 $wasTaxOnlyRefund = true;
+            } else {
+                // Adjustment-only credit memo (no items, no shipping, not tax-only).
+                // Without this guard, an empty cartItems array would tell TaxCloud
+                // to return the entire order. Instead, distribute the adjustment
+                // proportionally across remaining (unrefunded) items + shipping.
+                $distribution = $this->refundDistributor->distribute($creditmemo);
+                $this->tclogger->info(
+                    'returnOrder: adjustment-only refund; distributor action=' . $distribution['action']
+                    . ' (' . $distribution['reason'] . ')'
+                );
+                if ($distribution['action'] === \Taxcloud\Magento2\Model\RefundDistributor::ACTION_SKIP) {
+                    // Nothing meaningful to send to TaxCloud; treat as success.
+                    return true;
+                }
+                // ACTION_FULL_RETURN leaves cartItems empty (TaxCloud returns the remainder).
+                // ACTION_DISTRIBUTE replaces cartItems with the proportional distribution.
+                $cartItems = $distribution['cartItems'];
             }
         }
 

--- a/Model/RefundDistributor.php
+++ b/Model/RefundDistributor.php
@@ -91,7 +91,8 @@ class RefundDistributor
     public function distribute($creditmemo)
     {
         $order = $creditmemo->getOrder();
-        $adjustment = (float) $creditmemo->getBaseGrandTotal();
+        $adjustment = (float) $creditmemo->getAdjustmentPositive()
+            - (float) $creditmemo->getAdjustmentNegative();
 
         if ($adjustment < self::MIN_ADJUSTMENT) {
             return $this->result(
@@ -229,10 +230,14 @@ class RefundDistributor
     }
 
     /**
-     * taxRatio = 1 - (tax / (tax + subtotal))
+     * taxRatio = 1 - (tax / (tax + subtotalAfterDiscount))
      *
      * Mirrors the Shopify ETL formula. Without it, distributing a pre-tax
      * adjustment across pre-tax item prices would implicitly refund some tax.
+     *
+     * Uses the post-discount subtotal because tax is calculated on the
+     * discounted amount; using the pre-discount subtotal would inflate the
+     * ratio and over-distribute.
      *
      * @param \Magento\Sales\Model\Order $order
      * @return float
@@ -240,7 +245,8 @@ class RefundDistributor
     private function computeTaxRatio($order)
     {
         $tax = (float) $order->getTaxAmount();
-        $subtotal = (float) $order->getSubtotal();
+        // getDiscountAmount() is negative in Magento (e.g., -20.00 for a $20 coupon)
+        $subtotal = (float) $order->getSubtotal() + (float) $order->getDiscountAmount();
         $denom = $tax + $subtotal;
         if ($denom <= 0) {
             return 1.0;

--- a/Model/RefundDistributor.php
+++ b/Model/RefundDistributor.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * Taxcloud_Magento2
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @package    Taxcloud_Magento2
+ * @author     TaxCloud <service@taxcloud.net>
+ * @copyright  2021 The Federal Tax Authority, LLC d/b/a TaxCloud
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+namespace Taxcloud\Magento2\Model;
+
+use Taxcloud\Magento2\Logger\Logger;
+
+/**
+ * Distributes adjustment-only refund amounts proportionally across the
+ * remaining (unrefunded) items and shipping of an order, so TaxCloud's
+ * Returned API receives meaningful cart items instead of an empty array
+ * (which TaxCloud interprets as a full-order return).
+ *
+ * Approach mirrors the Shopify ETL refund pipeline: distribute the
+ * adjustment as fractional quantities of remaining items, scaled by a
+ * tax ratio so we don't over-refund tax.
+ */
+class RefundDistributor
+{
+    /** Caller should skip the TaxCloud Returned call entirely. */
+    const ACTION_SKIP = 'skip';
+
+    /** Caller should send empty cartItems so TaxCloud returns the remainder. */
+    const ACTION_FULL_RETURN = 'full_return';
+
+    /** Caller should send the returned cartItems to TaxCloud. */
+    const ACTION_DISTRIBUTE = 'distribute';
+
+    /** Below this threshold the adjustment is treated as floating-point noise. */
+    const MIN_ADJUSTMENT = 0.01;
+
+    /**
+     * Penny tolerance for the full-return fallback. If the adjustment is within
+     * this many dollars of the remaining order total, treat it as a full return.
+     */
+    const FULL_RETURN_TOLERANCE = 0.01;
+
+    /** Decimal precision for fractional quantities sent to TaxCloud. */
+    const QTY_PRECISION = 4;
+
+    /**
+     * @var ProductTicService
+     */
+    private $productTicService;
+
+    /**
+     * @var Logger
+     */
+    private $tclogger;
+
+    /**
+     * @param ProductTicService $productTicService
+     * @param Logger $tclogger
+     */
+    public function __construct(
+        ProductTicService $productTicService,
+        Logger $tclogger
+    ) {
+        $this->productTicService = $productTicService;
+        $this->tclogger = $tclogger;
+    }
+
+    /**
+     * Decide what to send to TaxCloud's Returned API for an adjustment-only
+     * credit memo (one with no line items and no shipping refunded).
+     *
+     * Returns an associative array:
+     *   [
+     *     'action'    => one of ACTION_SKIP | ACTION_FULL_RETURN | ACTION_DISTRIBUTE,
+     *     'cartItems' => array of cart items (empty unless action is DISTRIBUTE),
+     *     'reason'    => human-readable explanation (for logging),
+     *   ]
+     *
+     * @param \Magento\Sales\Model\Order\Creditmemo $creditmemo
+     * @return array
+     */
+    public function distribute($creditmemo)
+    {
+        $order = $creditmemo->getOrder();
+        $adjustment = (float) $creditmemo->getBaseGrandTotal();
+
+        if ($adjustment < self::MIN_ADJUSTMENT) {
+            return $this->result(
+                self::ACTION_SKIP,
+                [],
+                'adjustment ' . $adjustment . ' is below minimum ' . self::MIN_ADJUSTMENT
+            );
+        }
+
+        $remaining = $this->buildRemainingItems($order);
+        $remainingTotal = $this->sumRemaining($remaining);
+
+        if ($remainingTotal <= 0) {
+            return $this->result(
+                self::ACTION_SKIP,
+                [],
+                'no remaining items or shipping available to refund'
+            );
+        }
+
+        // Full-return fallback: adjustment effectively covers the whole remainder.
+        if ($adjustment >= ($remainingTotal - self::FULL_RETURN_TOLERANCE)) {
+            return $this->result(
+                self::ACTION_FULL_RETURN,
+                [],
+                'adjustment ' . $adjustment . ' covers remaining total ' . $remainingTotal
+                . ' (within $' . self::FULL_RETURN_TOLERANCE . ')'
+            );
+        }
+
+        $taxRatio = $this->computeTaxRatio($order);
+        $adjustmentPercent = ($taxRatio * $adjustment) / $remainingTotal;
+
+        $cartItems = [];
+        $index = 0;
+        foreach ($remaining as $entry) {
+            $distributedQty = round($entry['qty'] * $adjustmentPercent, self::QTY_PRECISION);
+            if ($distributedQty <= 0) {
+                continue;
+            }
+            $cartItems[] = [
+                'ItemID' => $entry['ItemID'],
+                'Index'  => $index++,
+                'TIC'    => $entry['TIC'],
+                'Price'  => $entry['price'],
+                'Qty'    => $distributedQty,
+            ];
+        }
+
+        if (empty($cartItems)) {
+            return $this->result(
+                self::ACTION_SKIP,
+                [],
+                'distribution rounded all quantities to zero (adjustment too small relative to remaining total)'
+            );
+        }
+
+        return $this->result(
+            self::ACTION_DISTRIBUTE,
+            $cartItems,
+            'distributed ' . $adjustment . ' across ' . count($cartItems) . ' remaining item(s)'
+            . ' using taxRatio=' . $taxRatio . ' and percent=' . $adjustmentPercent
+        );
+    }
+
+    /**
+     * Build the list of remaining (unrefunded) order items and shipping.
+     *
+     * Each entry: ['ItemID' => string, 'TIC' => string, 'price' => float, 'qty' => float]
+     *
+     * @param \Magento\Sales\Model\Order $order
+     * @return array
+     */
+    private function buildRemainingItems($order)
+    {
+        $remaining = [];
+
+        foreach ($order->getAllItems() as $item) {
+            // Skip child rows of configurable/bundle items — qty is on the parent.
+            if (method_exists($item, 'getParentItem') && $item->getParentItem()) {
+                continue;
+            }
+
+            $qtyOrdered = (float) $item->getQtyOrdered();
+            $qtyRefunded = (float) $item->getQtyRefunded();
+            $remainingQty = $qtyOrdered - $qtyRefunded;
+            if ($remainingQty <= 0) {
+                continue;
+            }
+
+            $unitPrice = (float) $item->getPrice();
+            $discountPerUnit = $qtyOrdered > 0
+                ? ((float) $item->getDiscountAmount() / $qtyOrdered)
+                : 0.0;
+            $effectivePrice = $unitPrice - $discountPerUnit;
+
+            if ($effectivePrice <= 0) {
+                continue;
+            }
+
+            $remaining[] = [
+                'ItemID' => $item->getSku(),
+                'TIC'    => $this->productTicService->getProductTic($item, 'returnOrderDistribute'),
+                'price'  => $effectivePrice,
+                'qty'    => $remainingQty,
+            ];
+        }
+
+        $shippingAmount = (float) $order->getShippingAmount();
+        $shippingRefunded = (float) $order->getShippingRefunded();
+        $remainingShipping = $shippingAmount - $shippingRefunded;
+        if ($remainingShipping > 0) {
+            $remaining[] = [
+                'ItemID' => 'shipping',
+                'TIC'    => $this->productTicService->getShippingTic(),
+                'price'  => $remainingShipping,
+                'qty'    => 1.0,
+            ];
+        }
+
+        return $remaining;
+    }
+
+    /**
+     * @param array $remaining
+     * @return float
+     */
+    private function sumRemaining(array $remaining)
+    {
+        $total = 0.0;
+        foreach ($remaining as $entry) {
+            $total += $entry['price'] * $entry['qty'];
+        }
+        return $total;
+    }
+
+    /**
+     * taxRatio = 1 - (tax / (tax + subtotal))
+     *
+     * Mirrors the Shopify ETL formula. Without it, distributing a pre-tax
+     * adjustment across pre-tax item prices would implicitly refund some tax.
+     *
+     * @param \Magento\Sales\Model\Order $order
+     * @return float
+     */
+    private function computeTaxRatio($order)
+    {
+        $tax = (float) $order->getTaxAmount();
+        $subtotal = (float) $order->getSubtotal();
+        $denom = $tax + $subtotal;
+        if ($denom <= 0) {
+            return 1.0;
+        }
+        return 1.0 - ($tax / $denom);
+    }
+
+    /**
+     * @param string $action
+     * @param array  $cartItems
+     * @param string $reason
+     * @return array
+     */
+    private function result($action, array $cartItems, $reason)
+    {
+        return [
+            'action'    => $action,
+            'cartItems' => $cartItems,
+            'reason'    => $reason,
+        ];
+    }
+}

--- a/Test/Unit/Mocks/MagentoMocks.php
+++ b/Test/Unit/Mocks/MagentoMocks.php
@@ -62,6 +62,13 @@ namespace Magento\Catalog\Model {
     }
 }
 
+namespace Magento\Catalog\Api {
+    interface ProductRepositoryInterface
+    {
+        public function getById($productId);
+    }
+}
+
 // Mock Magento Sales API
 namespace Magento\Sales\Api {
     interface OrderRepositoryInterface
@@ -89,9 +96,14 @@ namespace Magento\Sales\Model {
         public function getState() { return null; }
         public function getData($key = null) { return null; }
         public function setData($key, $value = null) { return $this; }
+        public function getAllItems() { return []; }
         public function getAllVisibleItems() { return []; }
         public function getBaseShippingAmount() { return 0; }
         public function getBaseTaxAmount() { return 0; }
+        public function getShippingAmount() { return 0; }
+        public function getShippingRefunded() { return 0; }
+        public function getSubtotal() { return 0; }
+        public function getTaxAmount() { return 0; }
         public function getInvoiceCollection() { return new \Magento\Sales\Model\ResourceModel\Order\Invoice\Collection(); }
     }
 }
@@ -105,8 +117,10 @@ namespace Magento\Sales\Model\Order {
         public function getProduct() { return null; }
         public function setProduct($product) { return $this; }
         public function getQtyOrdered() { return 0; }
+        public function getQtyRefunded() { return 0; }
         public function getPrice() { return 0; }
         public function getDiscountAmount() { return 0; }
+        public function getParentItem() { return null; }
     }
 
     class Order
@@ -117,6 +131,11 @@ namespace Magento\Sales\Model\Order {
         public function getAllVisibleItems() { return []; }
         public function setItems($items) { return $this; }
         public function getBaseTaxAmount() { return 0; }
+        public function getBaseShippingAmount() { return 0; }
+        public function getShippingAmount() { return 0; }
+        public function getShippingRefunded() { return 0; }
+        public function getSubtotal() { return 0; }
+        public function getTaxAmount() { return 0; }
     }
 
     class Creditmemo
@@ -322,6 +341,22 @@ namespace {
     }
 }
 
+// Mock PSR-3 Logger (used by Cancel observer when logging is disabled)
+namespace Psr\Log {
+    class NullLogger
+    {
+        public function info($message, array $context = []) { /* no-op */ }
+        public function emergency($message, array $context = []) { /* no-op */ }
+        public function alert($message, array $context = []) { /* no-op */ }
+        public function critical($message, array $context = []) { /* no-op */ }
+        public function error($message, array $context = []) { /* no-op */ }
+        public function warning($message, array $context = []) { /* no-op */ }
+        public function notice($message, array $context = []) { /* no-op */ }
+        public function debug($message, array $context = []) { /* no-op */ }
+        public function log($level, $message, array $context = []) { /* no-op */ }
+    }
+}
+
 // Mock TaxCloud Logger
 namespace Taxcloud\Magento2\Logger {
     class Logger
@@ -361,6 +396,18 @@ namespace Magento\Quote\Model\Quote {
         public function setRowTotalInclTax($total) { return $this; }
         public function setBaseRowTotalInclTax($total) { return $this; }
     }
+
+    class Address
+    {
+        public function getPostcode() { return null; }
+        public function getStreet() { return []; }
+        public function getCity() { return null; }
+        public function getRegionId() { return null; }
+        public function getRegionCode() { return null; }
+        public function getCountryId() { return null; }
+        public function getShippingAmount() { return 0; }
+        public function getAddress() { return null; }
+    }
 }
 
 namespace Magento\Quote\Model\Quote\Address {
@@ -379,6 +426,7 @@ namespace Magento\Quote\Api\Data {
     interface ShippingAssignmentInterface
     {
         public function getItems();
+        public function getShipping();
     }
 }
 
@@ -424,6 +472,7 @@ namespace Magento\Tax\Api\Data {
         public function getCode();
         public function getType();
         public function getRowTax();
+        public function getRowTotal();
     }
     interface TaxClassKeyInterface
     {
@@ -452,6 +501,7 @@ namespace Magento\Customer\Api\Data {
     interface CustomerInterface
     {
         public function getId();
+        public function getCustomAttribute($attributeCode);
     }
 
     interface AddressInterfaceFactory

--- a/Test/Unit/Mocks/MagentoMocks.php
+++ b/Test/Unit/Mocks/MagentoMocks.php
@@ -103,6 +103,7 @@ namespace Magento\Sales\Model {
         public function getShippingAmount() { return 0; }
         public function getShippingRefunded() { return 0; }
         public function getSubtotal() { return 0; }
+        public function getDiscountAmount() { return 0; }
         public function getTaxAmount() { return 0; }
         public function getInvoiceCollection() { return new \Magento\Sales\Model\ResourceModel\Order\Invoice\Collection(); }
     }
@@ -135,6 +136,7 @@ namespace Magento\Sales\Model\Order {
         public function getShippingAmount() { return 0; }
         public function getShippingRefunded() { return 0; }
         public function getSubtotal() { return 0; }
+        public function getDiscountAmount() { return 0; }
         public function getTaxAmount() { return 0; }
     }
 
@@ -148,6 +150,8 @@ namespace Magento\Sales\Model\Order {
         public function setShippingAmount($amount) { return $this; }
         public function getBaseGrandTotal() { return 0; }
         public function getBaseTaxAmount() { return 0; }
+        public function getAdjustmentPositive() { return 0; }
+        public function getAdjustmentNegative() { return 0; }
     }
 }
 

--- a/Test/Unit/Model/ApiTest.php
+++ b/Test/Unit/Model/ApiTest.php
@@ -31,6 +31,13 @@ use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\DataObject;
 use Taxcloud\Magento2\Model\CartItemResponseHandler;
 use Taxcloud\Magento2\Model\ProductTicService;
+use Taxcloud\Magento2\Model\RefundDistributor;
+use Magento\Tax\Api\TaxCalculationInterface;
+use Magento\Tax\Api\Data\QuoteDetailsInterfaceFactory;
+use Magento\Tax\Api\Data\QuoteDetailsItemInterfaceFactory;
+use Magento\Tax\Api\Data\TaxClassKeyInterfaceFactory;
+use Magento\Customer\Api\Data\AddressInterfaceFactory;
+use Magento\Customer\Api\Data\RegionInterfaceFactory;
 
 class ApiTest extends TestCase
 {
@@ -46,6 +53,13 @@ class ApiTest extends TestCase
     private $serializer;
     private $cartItemResponseHandler;
     private $productTicService;
+    private $taxCalculationService;
+    private $quoteDetailsFactory;
+    private $quoteDetailsItemFactory;
+    private $taxClassKeyFactory;
+    private $customerAddressFactory;
+    private $customerAddressRegionFactory;
+    private $refundDistributor;
     private $mockSoapClient;
     private $mockDataObject;
 
@@ -62,6 +76,20 @@ class ApiTest extends TestCase
         $this->serializer = $this->createMock(SerializerInterface::class);
         $this->cartItemResponseHandler = $this->createMock(CartItemResponseHandler::class);
         $this->productTicService = $this->createMock(ProductTicService::class);
+        $this->taxCalculationService = $this->createMock(TaxCalculationInterface::class);
+        $this->quoteDetailsFactory = $this->createMock(QuoteDetailsInterfaceFactory::class);
+        $this->quoteDetailsItemFactory = $this->createMock(QuoteDetailsItemInterfaceFactory::class);
+        $this->taxClassKeyFactory = $this->createMock(TaxClassKeyInterfaceFactory::class);
+        $this->customerAddressFactory = $this->createMock(AddressInterfaceFactory::class);
+        $this->customerAddressRegionFactory = $this->createMock(RegionInterfaceFactory::class);
+        $this->refundDistributor = $this->createMock(RefundDistributor::class);
+        // Default: behave like the original empty-cartItems path (full return) so existing
+        // tests that don't care about adjustment-only refunds continue to work as before.
+        $this->refundDistributor->method('distribute')->willReturn([
+            'action'    => RefundDistributor::ACTION_FULL_RETURN,
+            'cartItems' => [],
+            'reason'    => 'test default',
+        ]);
         $this->mockSoapClient = $this->getMockBuilder(\SoapClient::class)
             ->disableOriginalConstructor()
             ->addMethods(['Returned', 'lookup', 'authorizedWithCapture', 'OrderDetails'])
@@ -82,7 +110,14 @@ class ApiTest extends TestCase
             $this->logger,
             $this->serializer,
             $this->cartItemResponseHandler,
-            $this->productTicService
+            $this->productTicService,
+            $this->taxCalculationService,
+            $this->quoteDetailsFactory,
+            $this->quoteDetailsItemFactory,
+            $this->taxClassKeyFactory,
+            $this->customerAddressFactory,
+            $this->customerAddressRegionFactory,
+            $this->refundDistributor
         );
         $this->injectMockSoapClientIntoApi();
     }

--- a/Test/Unit/Model/ProductTicServiceTest.php
+++ b/Test/Unit/Model/ProductTicServiceTest.php
@@ -26,7 +26,7 @@ require_once __DIR__ . '/../../../Model/ProductTicService.php';
 use PHPUnit\Framework\TestCase;
 use Taxcloud\Magento2\Model\ProductTicService;
 use Magento\Framework\App\Config\ScopeConfigInterface;
-use Magento\Catalog\Model\ProductFactory;
+use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product;
 use Magento\Sales\Model\Order\Item;
 use Magento\Framework\Api\AttributeValue;
@@ -36,18 +36,18 @@ class ProductTicServiceTest extends TestCase
 {
     private $productTicService;
     private $scopeConfig;
-    private $productFactory;
+    private $productRepository;
     private $logger;
 
     protected function setUp(): void
     {
         $this->scopeConfig = $this->createMock(ScopeConfigInterface::class);
-        $this->productFactory = $this->createMock(ProductFactory::class);
+        $this->productRepository = $this->createMock(ProductRepositoryInterface::class);
         $this->logger = $this->createMock(Logger::class);
 
         $this->productTicService = new ProductTicService(
             $this->scopeConfig,
-            $this->productFactory,
+            $this->productRepository,
             $this->logger
         );
     }
@@ -67,12 +67,11 @@ class ProductTicServiceTest extends TestCase
 
         $product->method('getId')->willReturn(123);
 
-        $productModel->method('load')->with(123)->willReturnSelf();
         $productModel->method('getCustomAttribute')->with('taxcloud_tic')->willReturn($customAttribute);
 
         $customAttribute->method('getValue')->willReturn('20000');
 
-        $this->productFactory->method('create')->willReturn($productModel);
+        $this->productRepository->method('getById')->with(123)->willReturn($productModel);
 
         $result = $this->productTicService->getProductTic($item, 'testContext');
 
@@ -140,10 +139,9 @@ class ProductTicServiceTest extends TestCase
 
         $product->method('getId')->willReturn(456);
 
-        $productModel->method('load')->with(456)->willReturnSelf();
         $productModel->method('getCustomAttribute')->with('taxcloud_tic')->willReturn(null);
 
-        $this->productFactory->method('create')->willReturn($productModel);
+        $this->productRepository->method('getById')->with(456)->willReturn($productModel);
 
         $this->scopeConfig->method('getValue')
             ->with('tax/taxcloud_settings/default_tic', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)

--- a/Test/Unit/Model/RefundDistributorTest.php
+++ b/Test/Unit/Model/RefundDistributorTest.php
@@ -63,7 +63,7 @@ class RefundDistributorTest extends TestCase
     /**
      * Build a mock Order with given items, shipping, tax, subtotal.
      */
-    private function makeOrder(array $items, float $shipping = 0.0, float $shippingRefunded = 0.0, float $tax = 0.0, float $subtotal = 0.0)
+    private function makeOrder(array $items, float $shipping = 0.0, float $shippingRefunded = 0.0, float $tax = 0.0, float $subtotal = 0.0, float $discount = 0.0)
     {
         $order = $this->createMock(Order::class);
         $order->method('getAllItems')->willReturn($items);
@@ -71,17 +71,19 @@ class RefundDistributorTest extends TestCase
         $order->method('getShippingRefunded')->willReturn($shippingRefunded);
         $order->method('getTaxAmount')->willReturn($tax);
         $order->method('getSubtotal')->willReturn($subtotal);
+        $order->method('getDiscountAmount')->willReturn($discount);
         return $order;
     }
 
     /**
-     * Build a mock Creditmemo bound to the given order with the given grand total.
+     * Build a mock Creditmemo bound to the given order with the given adjustment.
      */
-    private function makeCreditmemo($order, float $grandTotal)
+    private function makeCreditmemo($order, float $adjustmentPositive, float $adjustmentNegative = 0.0)
     {
         $cm = $this->createMock(Creditmemo::class);
         $cm->method('getOrder')->willReturn($order);
-        $cm->method('getBaseGrandTotal')->willReturn($grandTotal);
+        $cm->method('getAdjustmentPositive')->willReturn($adjustmentPositive);
+        $cm->method('getAdjustmentNegative')->willReturn($adjustmentNegative);
         return $cm;
     }
 
@@ -116,7 +118,7 @@ class RefundDistributorTest extends TestCase
     public function testTaxRatioReducesDistribution()
     {
         $item = $this->makeItem('SKU-A', 1, 0, 100.0);
-        // tax=10, subtotal=100 → taxRatio = 1 - (10/110) = 0.9091
+        // tax=10, subtotal=100, discount=0 → taxRatio = 1 - (10/110) = 0.9091
         $order = $this->makeOrder([$item], 0.0, 0.0, 10.0, 100.0);
         $cm = $this->makeCreditmemo($order, 10.0);
 
@@ -124,7 +126,24 @@ class RefundDistributorTest extends TestCase
 
         $this->assertSame(RefundDistributor::ACTION_DISTRIBUTE, $result['action']);
         // adjustmentPercent = (0.9091 * 10) / 100 = 0.0909
-        // qty = 1 * 0.0909 = 0.0909 → rounded to 0.0909
+        $this->assertEqualsWithDelta(0.0909, $result['cartItems'][0]['Qty'], 0.0001);
+    }
+
+    /**
+     * Tax ratio uses post-discount subtotal so discounts don't inflate the ratio.
+     */
+    public function testTaxRatioUsesPostDiscountSubtotal()
+    {
+        $item = $this->makeItem('SKU-A', 1, 0, 100.0);
+        // subtotal=100, discount=-20 → post-discount=80, tax=8
+        // taxRatio = 1 - (8 / (8 + 80)) = 1 - (8/88) = 0.9091
+        $order = $this->makeOrder([$item], 0.0, 0.0, 8.0, 100.0, -20.0);
+        $cm = $this->makeCreditmemo($order, 10.0);
+
+        $result = $this->distributor->distribute($cm);
+
+        $this->assertSame(RefundDistributor::ACTION_DISTRIBUTE, $result['action']);
+        // adjustmentPercent = (0.9091 * 10) / 100 = 0.0909
         $this->assertEqualsWithDelta(0.0909, $result['cartItems'][0]['Qty'], 0.0001);
     }
 
@@ -306,5 +325,22 @@ class RefundDistributorTest extends TestCase
         $this->assertSame(RefundDistributor::ACTION_DISTRIBUTE, $result['action']);
         $this->assertCount(1, $result['cartItems']);
         $this->assertEquals('PARENT', $result['cartItems'][0]['ItemID']);
+    }
+
+    /**
+     * Negative adjustment (restocking fee) reduces the net adjustment amount.
+     */
+    public function testAdjustmentNegativeReducesNetAdjustment()
+    {
+        $item = $this->makeItem('SKU-A', 1, 0, 100.0);
+        $order = $this->makeOrder([$item], 0.0, 0.0, 0.0, 100.0);
+        // adjustmentPositive=10, adjustmentNegative=3 → net = 7
+        $cm = $this->makeCreditmemo($order, 10.0, 3.0);
+
+        $result = $this->distributor->distribute($cm);
+
+        $this->assertSame(RefundDistributor::ACTION_DISTRIBUTE, $result['action']);
+        // adjustmentPercent = (1 * 7) / 100 = 0.07
+        $this->assertEqualsWithDelta(0.07, $result['cartItems'][0]['Qty'], 0.0001);
     }
 }

--- a/Test/Unit/Model/RefundDistributorTest.php
+++ b/Test/Unit/Model/RefundDistributorTest.php
@@ -1,0 +1,310 @@
+<?php
+/**
+ * Taxcloud_Magento2
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @package    Taxcloud_Magento2
+ * @author     TaxCloud <service@taxcloud.net>
+ * @copyright  2021 The Federal Tax Authority, LLC d/b/a TaxCloud
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+namespace Taxcloud\Magento2\Test\Unit\Model;
+
+require_once __DIR__ . '/../Mocks/MagentoMocks.php';
+require_once __DIR__ . '/../../../Model/RefundDistributor.php';
+
+use PHPUnit\Framework\TestCase;
+use Taxcloud\Magento2\Model\RefundDistributor;
+use Taxcloud\Magento2\Model\ProductTicService;
+use Taxcloud\Magento2\Logger\Logger;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Item;
+use Magento\Sales\Model\Order\Creditmemo;
+
+class RefundDistributorTest extends TestCase
+{
+    private $distributor;
+    private $ticService;
+    private $logger;
+
+    protected function setUp(): void
+    {
+        $this->ticService = $this->createMock(ProductTicService::class);
+        $this->ticService->method('getProductTic')->willReturn('20010');
+        $this->ticService->method('getShippingTic')->willReturn('11010');
+
+        $this->logger = $this->createMock(Logger::class);
+
+        $this->distributor = new RefundDistributor($this->ticService, $this->logger);
+    }
+
+    /**
+     * Build a mock Item with the given attributes.
+     */
+    private function makeItem(string $sku, float $qtyOrdered, float $qtyRefunded, float $price, float $discount = 0.0)
+    {
+        $item = $this->createMock(Item::class);
+        $item->method('getSku')->willReturn($sku);
+        $item->method('getQtyOrdered')->willReturn($qtyOrdered);
+        $item->method('getQtyRefunded')->willReturn($qtyRefunded);
+        $item->method('getPrice')->willReturn($price);
+        $item->method('getDiscountAmount')->willReturn($discount);
+        $item->method('getParentItem')->willReturn(null);
+        return $item;
+    }
+
+    /**
+     * Build a mock Order with given items, shipping, tax, subtotal.
+     */
+    private function makeOrder(array $items, float $shipping = 0.0, float $shippingRefunded = 0.0, float $tax = 0.0, float $subtotal = 0.0)
+    {
+        $order = $this->createMock(Order::class);
+        $order->method('getAllItems')->willReturn($items);
+        $order->method('getShippingAmount')->willReturn($shipping);
+        $order->method('getShippingRefunded')->willReturn($shippingRefunded);
+        $order->method('getTaxAmount')->willReturn($tax);
+        $order->method('getSubtotal')->willReturn($subtotal);
+        return $order;
+    }
+
+    /**
+     * Build a mock Creditmemo bound to the given order with the given grand total.
+     */
+    private function makeCreditmemo($order, float $grandTotal)
+    {
+        $cm = $this->createMock(Creditmemo::class);
+        $cm->method('getOrder')->willReturn($order);
+        $cm->method('getBaseGrandTotal')->willReturn($grandTotal);
+        return $cm;
+    }
+
+    /**
+     * Adjustment-only $2 refund on a $130 order (2x $50 + 1x $30).
+     * Expected: distribute action with fractional quantities.
+     */
+    public function testDistributesAdjustmentAcrossRemainingItems()
+    {
+        $itemA = $this->makeItem('SKU-A', 2, 0, 50.0);
+        $itemB = $this->makeItem('SKU-B', 1, 0, 30.0);
+        $order = $this->makeOrder([$itemA, $itemB], 0.0, 0.0, 0.0, 130.0);
+        $cm = $this->makeCreditmemo($order, 2.0);
+
+        $result = $this->distributor->distribute($cm);
+
+        $this->assertSame(RefundDistributor::ACTION_DISTRIBUTE, $result['action']);
+        $this->assertCount(2, $result['cartItems']);
+
+        // adjustmentPercent = (1 * 2) / 130 = ~0.01538 (taxRatio is 1 since tax=0)
+        $this->assertEqualsWithDelta(0.0308, $result['cartItems'][0]['Qty'], 0.0001);
+        $this->assertEqualsWithDelta(0.0154, $result['cartItems'][1]['Qty'], 0.0001);
+
+        $this->assertEquals('SKU-A', $result['cartItems'][0]['ItemID']);
+        $this->assertEquals(50.0, $result['cartItems'][0]['Price']);
+        $this->assertEquals('20010', $result['cartItems'][0]['TIC']);
+    }
+
+    /**
+     * Tax ratio should reduce the effective adjustment so we don't over-refund tax.
+     */
+    public function testTaxRatioReducesDistribution()
+    {
+        $item = $this->makeItem('SKU-A', 1, 0, 100.0);
+        // tax=10, subtotal=100 → taxRatio = 1 - (10/110) = 0.9091
+        $order = $this->makeOrder([$item], 0.0, 0.0, 10.0, 100.0);
+        $cm = $this->makeCreditmemo($order, 10.0);
+
+        $result = $this->distributor->distribute($cm);
+
+        $this->assertSame(RefundDistributor::ACTION_DISTRIBUTE, $result['action']);
+        // adjustmentPercent = (0.9091 * 10) / 100 = 0.0909
+        // qty = 1 * 0.0909 = 0.0909 → rounded to 0.0909
+        $this->assertEqualsWithDelta(0.0909, $result['cartItems'][0]['Qty'], 0.0001);
+    }
+
+    /**
+     * Includes shipping in the distribution pool.
+     */
+    public function testIncludesShippingInDistribution()
+    {
+        $item = $this->makeItem('SKU-A', 1, 0, 65.0);
+        $order = $this->makeOrder([$item], 35.0, 0.0, 0.0, 65.0);
+        $cm = $this->makeCreditmemo($order, 10.0);
+
+        $result = $this->distributor->distribute($cm);
+
+        $this->assertSame(RefundDistributor::ACTION_DISTRIBUTE, $result['action']);
+        $this->assertCount(2, $result['cartItems']);
+
+        $shippingItem = null;
+        foreach ($result['cartItems'] as $ci) {
+            if ($ci['ItemID'] === 'shipping') {
+                $shippingItem = $ci;
+            }
+        }
+        $this->assertNotNull($shippingItem, 'shipping should be included in distribution');
+        $this->assertEquals(35.0, $shippingItem['Price']);
+        $this->assertEquals('11010', $shippingItem['TIC']);
+        // remainingTotal=100, percent = 10/100 = 0.10, shipping qty = 1 * 0.10 = 0.10
+        $this->assertEqualsWithDelta(0.10, $shippingItem['Qty'], 0.0001);
+    }
+
+    /**
+     * Skip prior-refunded items (qtyRefunded subtracted from qtyOrdered).
+     */
+    public function testSkipsAlreadyFullyRefundedItems()
+    {
+        $itemA = $this->makeItem('SKU-A', 2, 2, 50.0); // fully refunded already
+        $itemB = $this->makeItem('SKU-B', 1, 0, 30.0); // 1 remaining
+        $order = $this->makeOrder([$itemA, $itemB], 0.0, 0.0, 0.0, 130.0);
+        $cm = $this->makeCreditmemo($order, 1.0);
+
+        $result = $this->distributor->distribute($cm);
+
+        $this->assertSame(RefundDistributor::ACTION_DISTRIBUTE, $result['action']);
+        $this->assertCount(1, $result['cartItems']);
+        $this->assertEquals('SKU-B', $result['cartItems'][0]['ItemID']);
+    }
+
+    /**
+     * Adjustment within $0.01 of remaining total → full return fallback.
+     */
+    public function testFullReturnFallbackWhenAdjustmentEqualsRemaining()
+    {
+        $item = $this->makeItem('SKU-A', 1, 0, 100.0);
+        $order = $this->makeOrder([$item], 0.0, 0.0, 0.0, 100.0);
+        // adjustment = 100 (matches remainingTotal exactly)
+        $cm = $this->makeCreditmemo($order, 100.0);
+
+        $result = $this->distributor->distribute($cm);
+
+        $this->assertSame(RefundDistributor::ACTION_FULL_RETURN, $result['action']);
+        $this->assertEmpty($result['cartItems']);
+    }
+
+    /**
+     * Adjustment 99.99 vs remaining 100.00 → still triggers full return (within $0.01).
+     */
+    public function testFullReturnFallbackWithinPennyTolerance()
+    {
+        $item = $this->makeItem('SKU-A', 1, 0, 100.0);
+        $order = $this->makeOrder([$item], 0.0, 0.0, 0.0, 100.0);
+        $cm = $this->makeCreditmemo($order, 99.99);
+
+        $result = $this->distributor->distribute($cm);
+
+        $this->assertSame(RefundDistributor::ACTION_FULL_RETURN, $result['action']);
+    }
+
+    /**
+     * Adjustment 99.50 vs remaining 100.00 → distribute, NOT full return.
+     */
+    public function testDistributeJustOutsidePennyTolerance()
+    {
+        $item = $this->makeItem('SKU-A', 1, 0, 100.0);
+        $order = $this->makeOrder([$item], 0.0, 0.0, 0.0, 100.0);
+        $cm = $this->makeCreditmemo($order, 99.50);
+
+        $result = $this->distributor->distribute($cm);
+
+        $this->assertSame(RefundDistributor::ACTION_DISTRIBUTE, $result['action']);
+    }
+
+    /**
+     * Adjustment below MIN_ADJUSTMENT → skip entirely.
+     */
+    public function testSkipsForNegligibleAdjustment()
+    {
+        $item = $this->makeItem('SKU-A', 1, 0, 100.0);
+        $order = $this->makeOrder([$item], 0.0, 0.0, 0.0, 100.0);
+        $cm = $this->makeCreditmemo($order, 0.005);
+
+        $result = $this->distributor->distribute($cm);
+
+        $this->assertSame(RefundDistributor::ACTION_SKIP, $result['action']);
+        $this->assertEmpty($result['cartItems']);
+    }
+
+    /**
+     * No remaining items AND no remaining shipping → skip.
+     */
+    public function testSkipsWhenNoRemainingItemsOrShipping()
+    {
+        $itemA = $this->makeItem('SKU-A', 2, 2, 50.0);     // fully refunded
+        $order = $this->makeOrder([$itemA], 35.0, 35.0, 0.0, 100.0); // shipping fully refunded
+        $cm = $this->makeCreditmemo($order, 5.0);
+
+        $result = $this->distributor->distribute($cm);
+
+        $this->assertSame(RefundDistributor::ACTION_SKIP, $result['action']);
+    }
+
+    /**
+     * Discount per unit is subtracted from the effective price used in distribution.
+     */
+    public function testAppliesDiscountPerUnit()
+    {
+        // qty=2, price=50, discount=20 → effectivePrice = 50 - (20/2) = 40
+        $item = $this->makeItem('SKU-A', 2, 0, 50.0, 20.0);
+        $order = $this->makeOrder([$item], 0.0, 0.0, 0.0, 80.0);
+        $cm = $this->makeCreditmemo($order, 8.0);
+
+        $result = $this->distributor->distribute($cm);
+
+        $this->assertSame(RefundDistributor::ACTION_DISTRIBUTE, $result['action']);
+        $this->assertEquals(40.0, $result['cartItems'][0]['Price']);
+    }
+
+    /**
+     * Quantities should be rounded to 4 decimal places.
+     */
+    public function testQuantitiesRoundedTo4Decimals()
+    {
+        $item = $this->makeItem('SKU-A', 7, 0, 13.0); // remainingTotal = 91
+        $order = $this->makeOrder([$item], 0.0, 0.0, 0.0, 91.0);
+        $cm = $this->makeCreditmemo($order, 1.0);
+
+        $result = $this->distributor->distribute($cm);
+
+        $qty = $result['cartItems'][0]['Qty'];
+        // The string repr of qty should not exceed 4 decimal digits.
+        $this->assertMatchesRegularExpression('/^\d+(\.\d{1,4})?$/', (string) $qty);
+    }
+
+    /**
+     * Child items (configurable / bundle children) should be skipped.
+     */
+    public function testSkipsChildItems()
+    {
+        $parent = $this->createMock(Item::class);
+        $parent->method('getSku')->willReturn('PARENT');
+        $parent->method('getQtyOrdered')->willReturn(1.0);
+        $parent->method('getQtyRefunded')->willReturn(0.0);
+        $parent->method('getPrice')->willReturn(100.0);
+        $parent->method('getDiscountAmount')->willReturn(0.0);
+        $parent->method('getParentItem')->willReturn(null);
+
+        $child = $this->createMock(Item::class);
+        $child->method('getSku')->willReturn('CHILD');
+        $child->method('getQtyOrdered')->willReturn(1.0);
+        $child->method('getQtyRefunded')->willReturn(0.0);
+        $child->method('getPrice')->willReturn(0.0);
+        $child->method('getDiscountAmount')->willReturn(0.0);
+        $child->method('getParentItem')->willReturn($parent); // child of parent
+
+        $order = $this->makeOrder([$parent, $child], 0.0, 0.0, 0.0, 100.0);
+        $cm = $this->makeCreditmemo($order, 5.0);
+
+        $result = $this->distributor->distribute($cm);
+
+        $this->assertSame(RefundDistributor::ACTION_DISTRIBUTE, $result['action']);
+        $this->assertCount(1, $result['cartItems']);
+        $this->assertEquals('PARENT', $result['cartItems'][0]['ItemID']);
+    }
+}

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+    bootstrap="Test/Unit/bootstrap.php"
+    colors="true"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>Test/Unit/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/registration.php
+++ b/registration.php
@@ -15,8 +15,10 @@
  * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
  */
 
-\Magento\Framework\Component\ComponentRegistrar::register(
-    \Magento\Framework\Component\ComponentRegistrar::MODULE,
-    'Taxcloud_Magento2',
-    __DIR__
-);
+if (class_exists(\Magento\Framework\Component\ComponentRegistrar::class)) {
+    \Magento\Framework\Component\ComponentRegistrar::register(
+        \Magento\Framework\Component\ComponentRegistrar::MODULE,
+        'Taxcloud_Magento2',
+        __DIR__
+    );
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                          
Fixes a bug where Magento credit memos containing only an adjustment amount (no items, no shipping) were sent to TaxCloud's Returned API with empty `cartItems`, causing TaxCloud to refund the **entire order** including items and shipping the merchant never intended to refund.

The fix introduces a `RefundDistributor` service that distributes the adjustment proportionally across the order's remaining (unrefunded) items and shipping. 

## Changes                                                                                       
  - **New** `Model/RefundDistributor.php` Returns one of three actions:
    - `distribute` Proportional split across remaining items + shipping, sent as fractional quantities (4-decimal precision)
    - `full_return` When adjustment is within $0.01 of the remaining order total, send empty `cartItems` (TaxCloud returns the remainder)
    - `skip` When adjustment is < $0.01 or no remaining items exist
  - **Updated** `Model/Api.php` Inject `RefundDistributor` and call it in `returnOrder()` when `cartItems` is empty AND not a tax-only refund. Tax-only refund path unchanged.
  - **New** `Test/Unit/Model/RefundDistributorTest.php` 12 tests covering distribution math, tax ratio, shipping inclusion, prior-refunded items, full-return fallback, penny tolerance boundaries, negligible adjustment, no remaining items, discount per unit, qty rounding, and child items
  - **Updated** `Test/Unit/Model/ApiTest.php` Added missing constructor mocks (pre-existing v1.1.1-beta gap) plus default `RefundDistributor` mock behavior
  - **Updated** `Test/Unit/Mocks/MagentoMocks.php` Added `getQtyRefunded`, `getShippingRefunded`, `getParentItem`, etc. needed by the distributor; also fixed pre-existing test failures by adding `Psr\Log\NullLogger`, `Magento\Catalog\Api\ProductRepositoryInterface`, `Magento\Quote\Model\Quote\Address`, and a few missing methods on existing `Order/QuoteDetailsItem` mocks
  - **Updated** `Test/Unit/Model/ProductTicServiceTest.php` Updated to use `ProductRepositoryInterface` (constructor change introduced in `c76f7a5`, test was never updated)
                                                                                                                                                                                                                     

## Algorithm                                                                                     
For an adjustment-only credit memo:
1. Build remaining items: `qtyOrdered - qtyRefunded` per line item, plus `shippingAmount - shippingRefunded`
2. If `adjustment >= remainingTotal - $0.01` → send empty `cartItems` (TaxCloud returns the remainder)
3. Otherwise compute `taxRatio = 1 - (tax / (tax + subtotal))` to avoid over-refunding tax
4. `adjustmentPercent = (taxRatio × adjustment) / remainingTotal`
5. Send each remaining entry with `qty = round(remainingQty × adjustmentPercent, 4)`

## Out of scope                                                                                                                                                                                                     
  - Mixed credit memos (items + adjustment) — adjustment is still ignored when items are present. Tracked separately if it becomes an issue.
