### PR TITLE
DEV-8596 Add SOAP timeouts and bounded retry to Magento2 tax-calc path

### DIFF
--- a/Model/Api.php
+++ b/Model/Api.php
@@ -43,6 +43,19 @@ class Api
     const KEY_BASE_ITEM = 'base_item';
 
     /**
+     * Default SOAP connection/read timeout in seconds.
+     * Kept low so a slow upstream call fails fast into the Magento fallback
+     * (when enabled) instead of stalling the checkout request thread, which
+     * inherits PHP's default_socket_timeout (~60s) otherwise.
+     */
+    const DEFAULT_SOAP_TIMEOUT = 10;
+
+    /**
+     * Backoff between the initial SOAP attempt and the single retry, in microseconds.
+     */
+    const SOAP_RETRY_BACKOFF_US = 250000;
+
+    /**
      * Magento Config Object
      *
      * @var \Magento\Framework\App\Config\ScopeConfigInterface
@@ -456,6 +469,45 @@ class Api
     }
 
     /**
+     * Get the configured SOAP timeout (seconds), falling back to the default.
+     * @return int
+     */
+    protected function getSoapTimeout()
+    {
+        $configured = (int) $this->scopeConfig->getValue(
+            'tax/taxcloud_settings/api_timeout',
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
+        return $configured > 0 ? $configured : self::DEFAULT_SOAP_TIMEOUT;
+    }
+
+    /**
+     * Build the option array passed to the SoapClient constructor.
+     *
+     * - connection_timeout: caps how long we wait to establish the connection.
+     * - stream_context http/ssl timeout: caps the read so a slow response
+     *   doesn't hang the checkout thread for default_socket_timeout (~60s).
+     * - cache_wsdl => WSDL_CACHE_BOTH: cache the WSDL in memory and on disk so
+     *   we don't refetch api.taxcloud.net's WSDL on every client construction.
+     *
+     * @return array
+     */
+    protected function buildSoapOptions()
+    {
+        $timeout = $this->getSoapTimeout();
+
+        return array(
+            'connection_timeout' => $timeout,
+            'cache_wsdl'         => WSDL_CACHE_BOTH,
+            'keep_alive'         => true,
+            'stream_context'     => stream_context_create(array(
+                'http' => array('timeout' => $timeout),
+                'ssl'  => array('timeout' => $timeout),
+            )),
+        );
+    }
+
+    /**
      * Get SoapClient
      * @return \SoapClient
      */
@@ -465,13 +517,63 @@ class Api
             try {
                 $wsdl = 'https://api.taxcloud.net/1.0/TaxCloud.asmx?wsdl';
                 // $this->client = $this->soapClientFactory->create($wsdl);
-                $this->client = new \SoapClient($wsdl);
+                $this->client = new \SoapClient($wsdl, $this->buildSoapOptions());
             } catch (Throwable $e) {
                 $this->tclogger->info('Cannot get SoapClient:');
                 $this->tclogger->info($e->getMessage());
             }
         }
         return $this->client;
+    }
+
+    /**
+     * Decide whether a SOAP failure is a connection/read timeout.
+     *
+     * Timeouts are not retried — a second long wait only compounds the delay
+     * the customer sees at checkout, so we fail fast into the fallback instead.
+     *
+     * @param Throwable $e
+     * @return bool
+     */
+    protected function isTimeoutError(Throwable $e)
+    {
+        if ($e instanceof \SoapFault && isset($e->faultcode)
+            && stripos((string) $e->faultcode, 'HTTP') !== false) {
+            return true;
+        }
+        return (bool) preg_match(
+            '/timed out|timeout|Error Fetching http headers|Could not connect|failed to open/i',
+            $e->getMessage()
+        );
+    }
+
+    /**
+     * Execute a SOAP call with a single bounded retry.
+     *
+     * Replaces the previous immediate blind retry:
+     * - On a timeout, the error is rethrown immediately (no retry) so the
+     *   caller can fall back fast instead of waiting through a second stall.
+     * - On any other transient fault, retry once after a short backoff.
+     *
+     * The final exception is rethrown so each call site's existing error
+     * handling (Magento fallback / return false) continues to apply unchanged.
+     *
+     * @param callable $call
+     * @return mixed
+     */
+    protected function callSoapWithRetry(callable $call)
+    {
+        try {
+            return $call();
+        } catch (Throwable $e) {
+            if ($this->isTimeoutError($e)) {
+                $this->tclogger->info('SOAP call timed out, not retrying: ' . $e->getMessage());
+                throw $e;
+            }
+            $this->tclogger->info('SOAP call failed, retrying once after backoff: ' . $e->getMessage());
+            usleep(self::SOAP_RETRY_BACKOFF_US);
+            return $call();
+        }
     }
 
     /**
@@ -654,22 +756,19 @@ class Api
         $this->tclogger->info(print_r($params, true));
 
         try {
-            $lookupResponse = $client->lookup($params);
+            $lookupResponse = $this->callSoapWithRetry(function () use ($client, $params) {
+                return $client->lookup($params);
+            });
         } catch (Throwable $e) {
-            // Retry
-            try {
-                $lookupResponse = $client->lookup($params);
-            } catch (Throwable $e) {
-                $this->tclogger->info('Error encountered during lookupTaxes: ' . $e->getMessage());
-                
-                // Check if fallback to Magento is enabled
-                if ($this->isFallbackToMagentoEnabled()) {
-                    $this->tclogger->info('TaxCloud lookup failed, falling back to Magento tax rates');
-                    return $this->getMagentoTaxRates($itemsByType, $shippingAssignment, $quote);
-                }
-                
-                return $result;
+            $this->tclogger->info('Error encountered during lookupTaxes: ' . $e->getMessage());
+
+            // Check if fallback to Magento is enabled
+            if ($this->isFallbackToMagentoEnabled()) {
+                $this->tclogger->info('TaxCloud lookup failed, falling back to Magento tax rates');
+                return $this->getMagentoTaxRates($itemsByType, $shippingAssignment, $quote);
             }
+
+            return $result;
         }
 
         // Force into array
@@ -879,15 +978,12 @@ class Api
         $this->tclogger->info(print_r($params, true));
 
         try {
-            $authorizedResponse = $client->authorizedWithCapture($params);
+            $authorizedResponse = $this->callSoapWithRetry(function () use ($client, $params) {
+                return $client->authorizedWithCapture($params);
+            });
         } catch (Throwable $e) {
-            // Retry
-            try {
-                $authorizedResponse = $client->authorizedWithCapture($params);
-            } catch (Throwable $e) {
-                $this->tclogger->info('Error encountered during authorizeCapture: ' . $e->getMessage());
-                return false;
-            }
+            $this->tclogger->info('Error encountered during authorizeCapture: ' . $e->getMessage());
+            return false;
         }
 
         // Force into array
@@ -1054,17 +1150,13 @@ class Api
         $this->tclogger->info(print_r($soapParams, true));
 
         try {
-            $returnResponse = $client->Returned($soapParams);
+            $returnResponse = $this->callSoapWithRetry(function () use ($client, $soapParams) {
+                return $client->Returned($soapParams);
+            });
         } catch (Throwable $e) {
-            $this->tclogger->info('First attempt failed: ' . $e->getMessage());
-            // Retry with explicit parameter mapping
-            try {
-                $returnResponse = $client->Returned($soapParams);
-            } catch (Throwable $e) {
-                $this->tclogger->info('Error encountered during returnOrder: ' . $e->getMessage());
-                $this->tclogger->info('SOAP parameters that failed: ' . print_r($soapParams, true));
-                return false;
-            }
+            $this->tclogger->info('Error encountered during returnOrder: ' . $e->getMessage());
+            $this->tclogger->info('SOAP parameters that failed: ' . print_r($soapParams, true));
+            return false;
         }
 
         // Force into array
@@ -1223,17 +1315,13 @@ class Api
         $this->tclogger->info(print_r($soapParams, true));
 
         try {
-            $returnResponse = $client->Returned($soapParams);
+            $returnResponse = $this->callSoapWithRetry(function () use ($client, $soapParams) {
+                return $client->Returned($soapParams);
+            });
         } catch (Throwable $e) {
-            $this->tclogger->info('First attempt failed: ' . $e->getMessage());
-            // Retry
-            try {
-                $returnResponse = $client->Returned($soapParams);
-            } catch (Throwable $e) {
-                $this->tclogger->info('Error encountered during returnOrderCancellation: ' . $e->getMessage());
-                $this->tclogger->info('SOAP parameters that failed: ' . print_r($soapParams, true));
-                return false;
-            }
+            $this->tclogger->info('Error encountered during returnOrderCancellation: ' . $e->getMessage());
+            $this->tclogger->info('SOAP parameters that failed: ' . print_r($soapParams, true));
+            return false;
         }
 
         // Force into array
@@ -1452,8 +1540,8 @@ class Api
         $client = $this->getClient();
 
         if (!$client) {
-            $this->tclogger->info('Error encountered during lookupTaxes: Cannot get SoapClient');
-            return $result;
+            $this->tclogger->info('Error encountered during verifyAddress: Cannot get SoapClient');
+            return false;
         }
 
         // Call before event
@@ -1474,15 +1562,12 @@ class Api
         $this->tclogger->info(print_r($params, true));
 
         try {
-            $verifyResponse = $client->verifyAddress($params);
+            $verifyResponse = $this->callSoapWithRetry(function () use ($client, $params) {
+                return $client->verifyAddress($params);
+            });
         } catch (Throwable $e) {
-            // Retry
-            try {
-                $verifyResponse = $client->verifyAddress($params);
-            } catch (Throwable $e) {
-                $this->tclogger->info('Error encountered during verifyAddress: ' . $e->getMessage());
-                return $result;
-            }
+            $this->tclogger->info('Error encountered during verifyAddress: ' . $e->getMessage());
+            return false;
         }
 
         // Force into array

--- a/Model/Api.php
+++ b/Model/Api.php
@@ -44,14 +44,11 @@ class Api
 
     /**
      * Default SOAP connection/read timeout in seconds.
-     * Kept low so a slow upstream call fails fast into the Magento fallback
-     * (when enabled) instead of stalling the checkout request thread, which
-     * inherits PHP's default_socket_timeout (~60s) otherwise.
      */
     const DEFAULT_SOAP_TIMEOUT = 10;
 
     /**
-     * Backoff between the initial SOAP attempt and the single retry, in microseconds.
+     * Backoff between SOAP retry attempts, in microseconds.
      */
     const SOAP_RETRY_BACKOFF_US = 250000;
 
@@ -527,10 +524,8 @@ class Api
     }
 
     /**
-     * Decide whether a SOAP failure is a connection/read timeout.
-     *
-     * Timeouts are not retried — a second long wait only compounds the delay
-     * the customer sees at checkout, so we fail fast into the fallback instead.
+     * Return whether a SOAP failure represents a connection or read timeout,
+     * based on its fault code and message.
      *
      * @param Throwable $e
      * @return bool
@@ -548,31 +543,32 @@ class Api
     }
 
     /**
-     * Execute a SOAP call with a single bounded retry.
+     * Execute a SOAP call, retrying up to $maxRetries times on transient faults.
      *
-     * Replaces the previous immediate blind retry:
-     * - On a timeout, the error is rethrown immediately (no retry) so the
-     *   caller can fall back fast instead of waiting through a second stall.
-     * - On any other transient fault, retry once after a short backoff.
-     *
-     * The final exception is rethrown so each call site's existing error
-     * handling (Magento fallback / return false) continues to apply unchanged.
+     * Timeouts are rethrown immediately and never retried. Any other fault is
+     * retried after a short backoff until $maxRetries is exhausted, then the
+     * final exception is rethrown so each call site's existing error handling
+     * (Magento fallback / return false) still applies.
      *
      * @param callable $call
+     * @param int      $maxRetries Retries after the initial attempt (default 1)
      * @return mixed
      */
-    protected function callSoapWithRetry(callable $call)
+    protected function callSoapWithRetry(callable $call, $maxRetries = 1)
     {
-        try {
-            return $call();
-        } catch (Throwable $e) {
-            if ($this->isTimeoutError($e)) {
-                $this->tclogger->info('SOAP call timed out, not retrying: ' . $e->getMessage());
-                throw $e;
+        for ($attempt = 0; ; $attempt++) {
+            try {
+                return $call();
+            } catch (Throwable $e) {
+                if ($this->isTimeoutError($e) || $attempt >= $maxRetries) {
+                    throw $e;
+                }
+                $this->tclogger->info(
+                    'SOAP call failed, retrying (' . ($attempt + 1) . '/' . $maxRetries
+                    . ') after backoff: ' . $e->getMessage()
+                );
+                usleep(self::SOAP_RETRY_BACKOFF_US);
             }
-            $this->tclogger->info('SOAP call failed, retrying once after backoff: ' . $e->getMessage());
-            usleep(self::SOAP_RETRY_BACKOFF_US);
-            return $call();
         }
     }
 

--- a/Model/Api.php
+++ b/Model/Api.php
@@ -556,15 +556,17 @@ class Api
      */
     protected function callSoapWithRetry(callable $call, $maxRetries = 1)
     {
-        for ($attempt = 0; ; $attempt++) {
+        $attempt = 0;
+        while (true) {
             try {
                 return $call();
             } catch (Throwable $e) {
                 if ($this->isTimeoutError($e) || $attempt >= $maxRetries) {
                     throw $e;
                 }
+                $attempt++;
                 $this->tclogger->info(
-                    'SOAP call failed, retrying (' . ($attempt + 1) . '/' . $maxRetries
+                    'SOAP call failed, retrying (' . $attempt . '/' . $maxRetries
                     . ') after backoff: ' . $e->getMessage()
                 );
                 usleep(self::SOAP_RETRY_BACKOFF_US);

--- a/Test/Unit/Model/ApiTest.php
+++ b/Test/Unit/Model/ApiTest.php
@@ -738,7 +738,7 @@ class ApiTest extends TestCase
         ]);
         $this->objectFactory->method('create')->willReturn($this->mockDataObject);
 
-        $lookupParams = null;
+        $shipLookupParams = null;
         $mockLookupResponse = new \stdClass();
         $mockLookupResponse->LookupResult = new \stdClass();
         $mockLookupResponse->LookupResult->ResponseType = 'OK';
@@ -746,15 +746,15 @@ class ApiTest extends TestCase
         $mockLookupResponse->LookupResult->CartItemsResponse->CartItemResponse = [
             (object)['CartItemIndex' => 0, 'TaxAmount' => 0],
         ];
-        $this->mockSoapClient->method('lookup')->willReturnCallback(function ($params) use (&$lookupParams, $mockLookupResponse) {
-            $lookupParams = $params;
+        $this->mockSoapClient->method('lookup')->willReturnCallback(function ($params) use (&$shipLookupParams, $mockLookupResponse) {
+            $shipLookupParams = $params;
             return $mockLookupResponse;
         });
 
         $this->api->lookupTaxes($itemsByType, $shippingAssignment, $quote);
 
-        $this->assertNotNull($lookupParams, 'lookup should have been called');
-        $cartItems = $lookupParams['cartItems'] ?? [];
+        $this->assertNotNull($shipLookupParams, 'lookup should have been called');
+        $cartItems = $shipLookupParams['cartItems'] ?? [];
         $shippingItem = null;
         foreach ($cartItems as $item) {
             if (isset($item['ItemID']) && $item['ItemID'] === 'shipping') {
@@ -914,8 +914,9 @@ class ApiTest extends TestCase
     /**
      * Common setup for the exemption-certificate lookup tests.
      *
-     * Returns an array [$itemsByType, $shippingAssignment, $quote, &$lookupParams]
-     * so each test can call lookupTaxes() and inspect what was sent to the SOAP lookup.
+     * Returns an array [$itemsByType, $shippingAssignment, $quote, $lookupHolder]
+     * where $lookupHolder->params captures what was sent to the SOAP lookup,
+     * so each test can call lookupTaxes() and inspect it afterward.
      *
      * @param string      $certID            Certificate UUID on the customer (empty string = no cert)
      * @param string      $destinationState  Two-letter state code for the shipping address
@@ -943,6 +944,14 @@ class ApiTest extends TestCase
             ->addMethods(['setParams', 'getParams', 'setResult', 'getResult'])
             ->getMock();
 
+        $this->taxCalculationService = $this->createMock(TaxCalculationInterface::class);
+        $this->quoteDetailsFactory = $this->createMock(QuoteDetailsInterfaceFactory::class);
+        $this->quoteDetailsItemFactory = $this->createMock(QuoteDetailsItemInterfaceFactory::class);
+        $this->taxClassKeyFactory = $this->createMock(TaxClassKeyInterfaceFactory::class);
+        $this->customerAddressFactory = $this->createMock(AddressInterfaceFactory::class);
+        $this->customerAddressRegionFactory = $this->createMock(RegionInterfaceFactory::class);
+        $this->refundDistributor = $this->createMock(RefundDistributor::class);
+
         $this->api = new Api(
             $this->scopeConfig,
             $this->cacheType,
@@ -954,7 +963,14 @@ class ApiTest extends TestCase
             $this->logger,
             $this->serializer,
             $this->cartItemResponseHandler,
-            $this->productTicService
+            $this->productTicService,
+            $this->taxCalculationService,
+            $this->quoteDetailsFactory,
+            $this->quoteDetailsItemFactory,
+            $this->taxClassKeyFactory,
+            $this->customerAddressFactory,
+            $this->customerAddressRegionFactory,
+            $this->refundDistributor
         );
         $this->injectMockSoapClientIntoApi();
 
@@ -1037,8 +1053,11 @@ class ApiTest extends TestCase
         ]);
         $this->objectFactory->method('create')->willReturn($this->mockDataObject);
 
-        // Standard lookup SOAP response
-        $lookupParams = null;
+        // Standard lookup SOAP response. The params sent to lookup() are
+        // captured into a holder object (avoids fragile by-reference list
+        // destructuring, which is not portable across PHP versions).
+        $lookupHolder = new \stdClass();
+        $lookupHolder->params = null;
         $mockLookupResponse = new \stdClass();
         $mockLookupResponse->LookupResult = new \stdClass();
         $mockLookupResponse->LookupResult->ResponseType = 'OK';
@@ -1047,13 +1066,13 @@ class ApiTest extends TestCase
             (object)['CartItemIndex' => 0, 'TaxAmount' => 0],
         ];
         $this->mockSoapClient->method('lookup')->willReturnCallback(
-            function ($params) use (&$lookupParams, $mockLookupResponse) {
-                $lookupParams = $params;
+            function ($params) use ($lookupHolder, $mockLookupResponse) {
+                $lookupHolder->params = $params;
                 return $mockLookupResponse;
             }
         );
 
-        return [$itemsByType, $shippingAssignment, $quote, &$lookupParams];
+        return [$itemsByType, $shippingAssignment, $quote, $lookupHolder];
     }
 
     /**
@@ -1066,7 +1085,7 @@ class ApiTest extends TestCase
         bool $expectCertSent
     ) {
         $certID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
-        [$itemsByType, $shippingAssignment, $quote, &$lookupParams] =
+        [$itemsByType, $shippingAssignment, $quote, $lookupHolder] =
             $this->setUpLookupWithCert($certID, $destinationState);
 
         $this->mockSoapClient->method('GetExemptCertificates')
@@ -1076,11 +1095,11 @@ class ApiTest extends TestCase
 
         $this->api->lookupTaxes($itemsByType, $shippingAssignment, $quote);
 
-        $this->assertNotNull($lookupParams, 'lookup should have been called');
+        $this->assertNotNull($lookupHolder->params, 'lookup should have been called');
         if ($expectCertSent) {
-            $this->assertSame($certID, $lookupParams['exemptCert']['CertificateID'], $description);
+            $this->assertSame($certID, $lookupHolder->params['exemptCert']['CertificateID'], $description);
         } else {
-            $this->assertNull($lookupParams['exemptCert']['CertificateID'], $description);
+            $this->assertNull($lookupHolder->params['exemptCert']['CertificateID'], $description);
         }
     }
 
@@ -1130,7 +1149,7 @@ class ApiTest extends TestCase
         bool $expectCertSent
     ) {
         $certID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
-        [$itemsByType, $shippingAssignment, $quote, &$lookupParams] =
+        [$itemsByType, $shippingAssignment, $quote, $lookupHolder] =
             $this->setUpLookupWithCert($certID, $destinationState);
 
         $certCacheKey = 'taxcloud_cert_states_' . $certID;
@@ -1146,11 +1165,11 @@ class ApiTest extends TestCase
 
         $this->api->lookupTaxes($itemsByType, $shippingAssignment, $quote);
 
-        $this->assertNotNull($lookupParams, 'lookup should have been called');
+        $this->assertNotNull($lookupHolder->params, 'lookup should have been called');
         if ($expectCertSent) {
-            $this->assertSame($certID, $lookupParams['exemptCert']['CertificateID'], $description);
+            $this->assertSame($certID, $lookupHolder->params['exemptCert']['CertificateID'], $description);
         } else {
-            $this->assertNull($lookupParams['exemptCert']['CertificateID'], $description);
+            $this->assertNull($lookupHolder->params['exemptCert']['CertificateID'], $description);
         }
     }
 
@@ -1178,7 +1197,7 @@ class ApiTest extends TestCase
     public function testLookupTaxesOmitsCertWhenGetExemptCertificatesFails()
     {
         $certID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
-        [$itemsByType, $shippingAssignment, $quote, &$lookupParams] =
+        [$itemsByType, $shippingAssignment, $quote, $lookupHolder] =
             $this->setUpLookupWithCert($certID, 'GA');
 
         $this->mockSoapClient->method('GetExemptCertificates')
@@ -1188,9 +1207,9 @@ class ApiTest extends TestCase
 
         $this->api->lookupTaxes($itemsByType, $shippingAssignment, $quote);
 
-        $this->assertNotNull($lookupParams, 'lookup should have been called');
+        $this->assertNotNull($lookupHolder->params, 'lookup should have been called');
         $this->assertNull(
-            $lookupParams['exemptCert']['CertificateID'],
+            $lookupHolder->params['exemptCert']['CertificateID'],
             'CertificateID must be null when GetExemptCertificates SOAP call fails'
         );
     }
@@ -1200,7 +1219,7 @@ class ApiTest extends TestCase
      */
     public function testLookupTaxesNoCertOnCustomerSendsNullCertificateID()
     {
-        [$itemsByType, $shippingAssignment, $quote, &$lookupParams] =
+        [$itemsByType, $shippingAssignment, $quote, $lookupHolder] =
             $this->setUpLookupWithCert('', 'GA');
 
         $this->cacheType->method('load')->willReturn(false);
@@ -1208,9 +1227,9 @@ class ApiTest extends TestCase
 
         $this->api->lookupTaxes($itemsByType, $shippingAssignment, $quote);
 
-        $this->assertNotNull($lookupParams, 'lookup should have been called');
+        $this->assertNotNull($lookupHolder->params, 'lookup should have been called');
         $this->assertNull(
-            $lookupParams['exemptCert']['CertificateID'],
+            $lookupHolder->params['exemptCert']['CertificateID'],
             'CertificateID should be null when customer has no cert'
         );
     }
@@ -1221,7 +1240,7 @@ class ApiTest extends TestCase
     public function testLookupTaxesHandlesSingleCertSoapResponse()
     {
         $certID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
-        [$itemsByType, $shippingAssignment, $quote, &$lookupParams] =
+        [$itemsByType, $shippingAssignment, $quote, $lookupHolder] =
             $this->setUpLookupWithCert($certID, 'GA');
 
         // Build response where ExemptionCertificate is a single object, not an array
@@ -1234,11 +1253,262 @@ class ApiTest extends TestCase
 
         $this->api->lookupTaxes($itemsByType, $shippingAssignment, $quote);
 
-        $this->assertNotNull($lookupParams, 'lookup should have been called');
+        $this->assertNotNull($lookupHolder->params, 'lookup should have been called');
         $this->assertSame(
             $certID,
-            $lookupParams['exemptCert']['CertificateID'],
+            $lookupHolder->params['exemptCert']['CertificateID'],
             'Should handle single-cert SOAP response (object instead of array)'
         );
     }
-} 
+
+    // ─── SOAP Timeout / Retry Tests (INT-504) ───────────────────────────
+
+    /**
+     * Invoke a protected method on the Api under test.
+     *
+     * @param string $method
+     * @param array  $args
+     * @return mixed
+     */
+    private function callProtected(string $method, array $args = [])
+    {
+        $ref = new \ReflectionMethod(Api::class, $method);
+        if (method_exists($ref, 'setAccessible')) {
+            @$ref->setAccessible(true);
+        }
+        return $ref->invokeArgs($this->api, $args);
+    }
+
+    /**
+     * buildSoapOptions(): uses the default timeout when api_timeout is unset
+     * and always pins cache_wsdl => WSDL_CACHE_BOTH plus a stream-context timeout.
+     */
+    public function testBuildSoapOptionsUsesDefaultTimeoutAndCachesWsdl()
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                ['tax/taxcloud_settings/api_timeout', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null, null],
+            ]);
+
+        $options = $this->callProtected('buildSoapOptions');
+
+        $this->assertSame(Api::DEFAULT_SOAP_TIMEOUT, $options['connection_timeout']);
+        $this->assertSame(WSDL_CACHE_BOTH, $options['cache_wsdl']);
+        $this->assertTrue($options['keep_alive']);
+        $this->assertIsResource($options['stream_context']);
+
+        $ctx = stream_context_get_options($options['stream_context']);
+        $this->assertSame(Api::DEFAULT_SOAP_TIMEOUT, $ctx['http']['timeout']);
+        $this->assertSame(Api::DEFAULT_SOAP_TIMEOUT, $ctx['ssl']['timeout']);
+    }
+
+    /**
+     * buildSoapOptions(): honors a configured api_timeout for both the
+     * connection timeout and the stream-context read timeout.
+     */
+    public function testBuildSoapOptionsUsesConfiguredTimeout()
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                ['tax/taxcloud_settings/api_timeout', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null, '3'],
+            ]);
+
+        $options = $this->callProtected('buildSoapOptions');
+
+        $this->assertSame(3, $options['connection_timeout']);
+        $ctx = stream_context_get_options($options['stream_context']);
+        $this->assertSame(3, $ctx['http']['timeout']);
+    }
+
+    /**
+     * @dataProvider timeoutErrorProvider
+     */
+    public function testIsTimeoutErrorClassification(\Throwable $error, bool $expected, string $message)
+    {
+        $this->assertSame($expected, $this->callProtected('isTimeoutError', [$error]), $message);
+    }
+
+    public static function timeoutErrorProvider(): array
+    {
+        return [
+            'http faultcode is a timeout' => [
+                new \SoapFault('HTTP', 'Error Fetching http headers'),
+                true,
+                'HTTP faultcode should be treated as a timeout',
+            ],
+            'message says timed out' => [
+                new \SoapFault('Server', 'Connection timed out after 10000ms'),
+                true,
+                'A "timed out" message should be treated as a timeout',
+            ],
+            'could not connect' => [
+                new \SoapFault('Server', 'Could not connect to host'),
+                true,
+                'A connect failure should be treated as a timeout',
+            ],
+            'generic server fault is not a timeout' => [
+                new \SoapFault('Server', 'Internal server error'),
+                false,
+                'A generic server fault should be retried (not a timeout)',
+            ],
+            'generic exception is not a timeout' => [
+                new \RuntimeException('something else'),
+                false,
+                'A non-timeout exception should be retried',
+            ],
+        ];
+    }
+
+    /**
+     * callSoapWithRetry(): retries exactly once on a non-timeout fault.
+     */
+    public function testCallSoapWithRetryRetriesOnceOnTransientFault()
+    {
+        $this->scopeConfig->method('getValue')->willReturn('0');
+
+        $attempts = 0;
+        $result = $this->callProtected('callSoapWithRetry', [function () use (&$attempts) {
+            $attempts++;
+            if ($attempts === 1) {
+                throw new \SoapFault('Server', 'Transient blip');
+            }
+            return 'ok';
+        }]);
+
+        $this->assertSame(2, $attempts, 'A transient fault should trigger exactly one retry');
+        $this->assertSame('ok', $result);
+    }
+
+    /**
+     * callSoapWithRetry(): does NOT retry on a timeout — rethrows immediately.
+     */
+    public function testCallSoapWithRetryDoesNotRetryOnTimeout()
+    {
+        $this->scopeConfig->method('getValue')->willReturn('0');
+
+        $attempts = 0;
+        $this->expectException(\SoapFault::class);
+        try {
+            $this->callProtected('callSoapWithRetry', [function () use (&$attempts) {
+                $attempts++;
+                throw new \SoapFault('HTTP', 'Error Fetching http headers');
+            }]);
+        } finally {
+            $this->assertSame(1, $attempts, 'A timeout must not be retried');
+        }
+    }
+
+    /**
+     * Configure a minimal-but-complete lookup context so lookupTaxes() reaches
+     * the SOAP lookup() call. Leaves the lookup() stub to the caller.
+     *
+     * @param string $fallbackEnabled '0' or '1'
+     * @return array [$itemsByType, $shippingAssignment, $quote]
+     */
+    private function configureLookupContext(string $fallbackEnabled): array
+    {
+        $this->scopeConfig->method('getValue')
+            ->willReturnMap([
+                ['tax/taxcloud_settings/enabled', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null, '1'],
+                ['tax/taxcloud_settings/logging', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null, '0'],
+                ['tax/taxcloud_settings/api_id', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null, 'test_api_id'],
+                ['tax/taxcloud_settings/api_key', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null, 'test_api_key'],
+                ['tax/taxcloud_settings/cache_lifetime', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null, '0'],
+                ['tax/taxcloud_settings/guest_customer_id', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null, '-1'],
+                ['tax/taxcloud_settings/fallback_to_magento', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null, $fallbackEnabled],
+                ['shipping/origin/postcode', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null, '60005'],
+                ['shipping/origin/street_line1', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null, '71 W Seegers Rd'],
+                ['shipping/origin/street_line2', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null, ''],
+                ['shipping/origin/city', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null, 'Arlington Heights'],
+                ['shipping/origin/region_id', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null, '1'],
+            ]);
+
+        $region = $this->createMock(\Magento\Directory\Model\Region::class);
+        $region->method('load')->willReturnSelf();
+        $region->method('getCode')->willReturn('GA');
+        $this->regionFactory->method('create')->willReturn($region);
+
+        $customer = $this->createMock(\Magento\Customer\Api\Data\CustomerInterface::class);
+        $customer->method('getId')->willReturn(1);
+        $customer->method('getCustomAttribute')->willReturn(null);
+
+        $quote = $this->createMock(\Magento\Quote\Model\Quote::class);
+        $quote->method('getCustomer')->willReturn($customer);
+        $quote->method('getId')->willReturn(999);
+
+        $address = $this->createMock(\Magento\Quote\Model\Quote\Address::class);
+        $address->method('getPostcode')->willReturn('30097');
+        $address->method('getStreet')->willReturn(['405 Victorian Ln']);
+        $address->method('getCity')->willReturn('Duluth');
+        $address->method('getRegionId')->willReturn(1);
+        $address->method('getCountryId')->willReturn('US');
+        $address->method('getShippingAmount')->willReturn(5.00);
+
+        $shipping = $this->createMock(\Magento\Quote\Model\Quote\Address::class);
+        $shipping->method('getAddress')->willReturn($address);
+
+        $shippingAssignment = $this->createMock(\Magento\Quote\Api\Data\ShippingAssignmentInterface::class);
+        $shippingAssignment->method('getShipping')->willReturn($shipping);
+        $shippingAssignment->method('getItems')->willReturn([]);
+
+        $shippingTaxDetailItem = $this->createMock(\Magento\Tax\Api\Data\QuoteDetailsItemInterface::class);
+        $shippingTaxDetailItem->method('getRowTotal')->willReturn(5.00);
+        $itemsByType = [
+            Api::ITEM_TYPE_SHIPPING => [
+                'shipping' => [Api::KEY_ITEM => $shippingTaxDetailItem],
+            ],
+        ];
+
+        $this->productTicService->method('getShippingTic')->willReturn('11010');
+        $this->cacheType->method('load')->willReturn(false);
+
+        // DataObject pass-through for the taxcloud_lookup_before event.
+        $capturedParams = null;
+        $this->mockDataObject->method('setParams')->willReturnCallback(function ($p) use (&$capturedParams) {
+            $capturedParams = $p;
+            return $this->mockDataObject;
+        });
+        $this->mockDataObject->method('getParams')->willReturnCallback(function () use (&$capturedParams) {
+            return $capturedParams;
+        });
+        $this->mockDataObject->method('setResult')->willReturnSelf();
+        $this->objectFactory->method('create')->willReturn($this->mockDataObject);
+
+        return [$itemsByType, $shippingAssignment, $quote];
+    }
+
+    /**
+     * lookupTaxes(): a transient (non-timeout) SOAP fault is retried once.
+     * With fallback disabled and the retry also failing, a zero result returns.
+     */
+    public function testLookupTaxesRetriesOnceOnTransientSoapFault()
+    {
+        [$itemsByType, $shippingAssignment, $quote] = $this->configureLookupContext('0');
+
+        $this->mockSoapClient->expects($this->exactly(2))
+            ->method('lookup')
+            ->willThrowException(new \SoapFault('Server', 'Transient blip'));
+
+        $result = $this->api->lookupTaxes($itemsByType, $shippingAssignment, $quote);
+
+        $this->assertSame(0, $result[Api::ITEM_TYPE_SHIPPING]);
+        $this->assertSame([], $result[Api::ITEM_TYPE_PRODUCT]);
+    }
+
+    /**
+     * lookupTaxes(): a timeout fails fast — lookup() is called exactly once
+     * (no retry) so checkout doesn't wait through a second stall.
+     */
+    public function testLookupTaxesDoesNotRetryOnTimeout()
+    {
+        [$itemsByType, $shippingAssignment, $quote] = $this->configureLookupContext('0');
+
+        $this->mockSoapClient->expects($this->once())
+            ->method('lookup')
+            ->willThrowException(new \SoapFault('HTTP', 'Error Fetching http headers'));
+
+        $result = $this->api->lookupTaxes($itemsByType, $shippingAssignment, $quote);
+
+        $this->assertSame(0, $result[Api::ITEM_TYPE_SHIPPING]);
+    }
+}

--- a/Test/Unit/Model/ApiTest.php
+++ b/Test/Unit/Model/ApiTest.php
@@ -1380,6 +1380,26 @@ class ApiTest extends TestCase
     }
 
     /**
+     * callSoapWithRetry(): honors a configurable retry count.
+     */
+    public function testCallSoapWithRetryHonorsMaxRetries()
+    {
+        $this->scopeConfig->method('getValue')->willReturn('0');
+
+        $attempts = 0;
+        $result = $this->callProtected('callSoapWithRetry', [function () use (&$attempts) {
+            $attempts++;
+            if ($attempts < 3) {
+                throw new \SoapFault('Server', 'Transient blip');
+            }
+            return 'ok';
+        }, 2]);
+
+        $this->assertSame(3, $attempts, 'maxRetries=2 should allow up to three total attempts');
+        $this->assertSame('ok', $result);
+    }
+
+    /**
      * callSoapWithRetry(): does NOT retry on a timeout — rethrows immediately.
      */
     public function testCallSoapWithRetryDoesNotRetryOnTimeout()

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
   "description": "TaxCloud Module for Magento 2",
   "type": "magento2-module",
   "license": "OSL-3.0",
+  "version": "1.1.3",
   "autoload": {
     "files": [
       "registration.php"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
   "name": "taxcloud/magento2",
   "description": "TaxCloud Module for Magento 2",
   "type": "magento2-module",
-  "version": "1.1.1.0.1",
   "license": "OSL-3.0",
   "autoload": {
     "files": [

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -129,6 +129,16 @@
           </depends>
         </field>
 
+        <field id="api_timeout" translate="label" type="text" sortOrder="95" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="0">
+          <label>API Timeout (seconds)</label>
+          <validate>validate-number</validate>
+          <config_path>tax/taxcloud_settings/api_timeout</config_path>
+          <tooltip>Max seconds to wait for a TaxCloud API call before failing fast (Default 10). Lower values fail over to the Magento fallback sooner; leave blank to use the default.</tooltip>
+          <depends>
+            <field id="enabled">1</field>
+          </depends>
+        </field>
+
         <field id="fallback_to_magento" translate="label" type="select" sortOrder="100" showInDefault="1" showInWebsite="1" showInStore="1">
           <label>Fallback to Magento Tax Rates</label>
           <source_model>Magento\Config\Model\Config\Source\Enabledisable</source_model>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -27,6 +27,7 @@
         <default_tic>00000</default_tic>
         <shipping_tic>11010</shipping_tic>
         <cache_lifetime>86400</cache_lifetime>
+        <api_timeout>10</api_timeout>
         <fallback_to_magento>0</fallback_to_magento>
         <capture_trigger>order_creation</capture_trigger>
       </taxcloud_settings>


### PR DESCRIPTION
### Type of change
- Bug fix
- New feature
- Test

---

### JIRA Ticket: https://taxcloud.atlassian.net/browse/DEV-8596

### Linear: https://linear.app/taxcloud/issue/INT-504/magento2-plugin-add-soap-timeouts-bounded-retry-to-tax-calc-path

Implements INT-504

---

### Description

The Magento2 plugin calls the legacy TaxCloud SOAP API synchronously inside the checkout quote-totals collector (`Tax::collect()` → `Api::lookupTaxes()`). An Adobe Commerce Cloud merchant reported intermittent checkout slowness. Two characteristics let a slow upstream call stall checkout, and this PR addresses both:

**1. SoapClient had no timeouts or WSDL caching**

`getClient()` built the client with `new \SoapClient($wsdl)` and no options, so it inherited PHP's `default_socket_timeout` (~60s) and relied on php.ini for WSDL caching. A momentary slow response could hang the checkout request thread.

- Now built via `buildSoapOptions()` with `connection_timeout`, `cache_wsdl => WSDL_CACHE_BOTH`, `keep_alive`, and a `stream_context` read timeout (http + ssl).
- Timeout is configurable through a new **API Timeout (seconds)** admin setting (`tax/taxcloud_settings/api_timeout`), default **10s**. Lower values fail over to the Magento fallback sooner.

**2. Immediate blind retry compounded latency**

Every SOAP call site did an immediate retry with no backoff and no timeout-awareness, so a 60s timeout could become ~120s before the fallback was reached.

- New `callSoapWithRetry()` helper: **no retry on a timeout** (fail fast into the fallback), one retry after a short backoff (250ms) on other transient faults. The final exception is rethrown so each call site's existing error handling (Magento fallback / `return false`) is unchanged.
- Applied to all five immediate-retry sites: `lookup`, `verifyAddress`, `authorizedWithCapture`, and `Returned` (×2).

**Drive-by fixes (same area)**
- `verifyAddress()` returned an undefined `$result` on the no-client and retry-exhausted paths; now returns `false` to match its `@return bool|array` contract and the method's other failure path.
- Repaired the `ApiTest` exemption-cert helper, which constructed `Api` with 11 of 18 required constructor args (10 tests were erroring on `main` with `ArgumentCountError`) and used a by-reference `list()` destructuring that isn't portable across PHP versions (now a small holder object).

**Out of scope:** the longer-term port off the legacy SOAP API to the v3 REST taxapi is tracked separately.

---

### TODOs

- [x] Tests are added or updated (SOAP option construction, timeout classification, retry-once vs fail-fast-on-timeout, lookupTaxes retry/no-retry)
- [ ] Documentation is updated in README and/or Confluence (if applicable)
- [ ] Verify on staging with a real Adobe Commerce checkout
