### PR TITLE
DEV-9171 Magento cancel: use local capture flag instead of license-gated OrderDetails

### DIFF
--- a/Observer/Sales/Cancel.php
+++ b/Observer/Sales/Cancel.php
@@ -145,11 +145,10 @@ class Cancel implements ObserverInterface
             return;
         }
 
-        $details = $this->tcapi->getOrderDetails($order);
-        if (!$details || empty($details['CapturedDate'])) {
+        if (!$this->wasCapturedInTaxcloud($order)) {
             $this->tclogger->info(
                 'TaxCloud Cancel: skipping order ' . $order->getIncrementId()
-                . ' (order was not captured in TaxCloud or OrderDetails unavailable)'
+                . ' (order was not captured in TaxCloud or capture state unavailable)'
             );
             return;
         }
@@ -167,5 +166,27 @@ class Cancel implements ObserverInterface
                 'TaxCloud Cancel: Returned completed for order ' . $order->getIncrementId()
             );
         }
+    }
+
+    /**
+     * Decide whether the order was captured in TaxCloud.
+     *
+     * Primary signal is the local taxcloud_captured flag set at capture time, which
+     * needs no API call. For legacy orders placed before that flag existed, fall back
+     * to the OrderDetails API. OrderDetails is license-gated and getOrderDetails()
+     * returns null when it is unavailable, so a merchant without that license simply
+     * skips the fallback rather than erroring.
+     *
+     * @param Order $order
+     * @return bool
+     */
+    private function wasCapturedInTaxcloud(Order $order)
+    {
+        if ($order->getData('taxcloud_captured')) {
+            return true;
+        }
+
+        $details = $this->tcapi->getOrderDetails($order);
+        return $details && !empty($details['CapturedDate']);
     }
 }

--- a/Observer/Sales/Complete.php
+++ b/Observer/Sales/Complete.php
@@ -54,17 +54,28 @@ class Complete implements ObserverInterface
     protected $tclogger;
 
     /**
+     * Sales order resource, used to persist the taxcloud_captured flag without
+     * re-dispatching the full order save.
+     *
+     * @var \Magento\Sales\Model\ResourceModel\Order
+     */
+    protected $orderResource;
+
+    /**
      * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
      * @param \Taxcloud\Magento2\Model\Api $tcapi
      * @param \Taxcloud\Magento2\Logger\Logger $tclogger
+     * @param \Magento\Sales\Model\ResourceModel\Order $orderResource
      */
     public function __construct(
         \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Taxcloud\Magento2\Model\Api $tcapi,
-        \Taxcloud\Magento2\Logger\Logger $tclogger
+        \Taxcloud\Magento2\Logger\Logger $tclogger,
+        \Magento\Sales\Model\ResourceModel\Order $orderResource
     ) {
         $this->scopeConfig = $scopeConfig;
         $this->tcapi = $tcapi;
+        $this->orderResource = $orderResource;
 
         if ($scopeConfig->getValue('tax/taxcloud_settings/logging', \Magento\Store\Model\ScopeInterface::SCOPE_STORE)) {
             $this->tclogger = $tclogger;
@@ -125,7 +136,31 @@ class Complete implements ObserverInterface
             return;
         }
 
-        $this->tcapi->authorizeCapture($order);
+        if ($this->tcapi->authorizeCapture($order)) {
+            $this->markCapturedInTaxcloud($order);
+        }
+    }
+
+    /**
+     * Record on the order that it was captured in TaxCloud. The cancel flow reads this
+     * flag instead of the license-gated OrderDetails API. saveAttribute persists the
+     * single column without re-dispatching the full order save.
+     *
+     * @param \Magento\Sales\Model\Order $order
+     */
+    private function markCapturedInTaxcloud($order)
+    {
+        try {
+            $order->setData('taxcloud_captured', 1);
+            $this->orderResource->saveAttribute($order, 'taxcloud_captured');
+        } catch (\Throwable $e) {
+            // Non-fatal: capture already succeeded in TaxCloud. Cancel can still fall
+            // back to OrderDetails if the flag was not persisted.
+            $this->tclogger->info(
+                'TaxCloud: could not persist taxcloud_captured for order '
+                . $order->getIncrementId() . ': ' . $e->getMessage()
+            );
+        }
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ When an order is canceled before any invoice is created, the extension automatic
 2. **Conditions**: Returned is only called when:
    - The order state is canceled (entire order canceled, not partial).
    - The order has no invoices (unpaid; refunds continue to use the credit memo flow).
-   - TaxCloud reports the order as captured: the extension calls TaxCloud's **OrderDetails** API and only calls Returned when the response includes a non-empty **CapturedDate**. This uses TaxCloud as the source of truth and works for existing orders captured before the extension was installed or after database migrations.
+   - The order was captured in TaxCloud. The extension records this locally (a `taxcloud_captured` flag set on the order when capture succeeds), so the cancel decision needs no extra API call. For legacy orders placed before that flag existed, the extension falls back to TaxCloud's **OrderDetails** API and calls Returned when the response includes a non-empty **CapturedDate**. `OrderDetails` is a license-gated API; when it is unavailable the fallback is skipped safely (the order is treated as not captured) rather than causing an error.
 
 3. **TaxCloud API call**: The extension calls the `Returned` API for the full order (all items and shipping), using the same `taxcloud_returned_before` and `taxcloud_returned_after` events (with `creditmemo` null for cancellation).
 

--- a/Test/Unit/Observer/Sales/CancelTest.php
+++ b/Test/Unit/Observer/Sales/CancelTest.php
@@ -148,6 +148,39 @@ class CancelTest extends TestCase
     }
 
     /**
+     * When the local taxcloud_captured flag is set, Returned is called and the
+     * license-gated OrderDetails API is never queried.
+     */
+    public function testProcessOrderCancelUsesLocalCapturedFlagWithoutOrderDetails()
+    {
+        $scopeConfig = $this->createMock(\Magento\Framework\App\Config\ScopeConfigInterface::class);
+        $scopeConfig->method('getValue')->willReturnMap([
+            ['tax/taxcloud_settings/enabled', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null, '1'],
+            ['tax/taxcloud_settings/logging', \Magento\Store\Model\ScopeInterface::SCOPE_STORE, null, '0']
+        ]);
+
+        $tcapi = $this->createMock(\Taxcloud\Magento2\Model\Api::class);
+        $tcapi->expects($this->never())->method('getOrderDetails');
+        $tcapi->expects($this->once())->method('returnOrderCancellation')->willReturn(true);
+
+        $logger = $this->createMock(\Taxcloud\Magento2\Logger\Logger::class);
+        $observer = new Cancel($scopeConfig, $tcapi, $logger);
+
+        $order = $this->createMock(Order::class);
+        $order->method('getId')->willReturn(1);
+        $order->method('getIncrementId')->willReturn('10006');
+        $order->method('getState')->willReturn(Order::STATE_CANCELED);
+        $order->method('getData')->with('taxcloud_captured')->willReturn(1);
+        $invoiceCollection = $this->createMock(\Magento\Sales\Model\ResourceModel\Order\Invoice\Collection::class);
+        $invoiceCollection->method('getSize')->willReturn(0);
+        $order->method('getInvoiceCollection')->willReturn($invoiceCollection);
+
+        $observerObj = $this->eventObserver('order_cancel_after', $order);
+
+        $observer->execute($observerObj);
+    }
+
+    /**
      * When all conditions are met (including TaxCloud OrderDetails shows CapturedDate), returnOrderCancellation is called.
      */
     public function testProcessOrderCancelCallsReturnWhenConditionsMet()

--- a/Test/Unit/Observer/Sales/CompleteTest.php
+++ b/Test/Unit/Observer/Sales/CompleteTest.php
@@ -65,6 +65,15 @@ class CompleteTest extends TestCase
     }
 
     /**
+     * Build a sales order resource mock. Tests that do not stub authorizeCapture()
+     * to return true never reach saveAttribute, so no expectations are needed here.
+     */
+    private function makeOrderResource(): \Magento\Sales\Model\ResourceModel\Order
+    {
+        return $this->createMock(\Magento\Sales\Model\ResourceModel\Order::class);
+    }
+
+    /**
      * Build an Order mock with the given invoice / shipment collection sizes.
      */
     private function buildOrder(int $invoiceCollectionSize = 0, int $shipmentCollectionSize = 0): Order
@@ -94,7 +103,61 @@ class CompleteTest extends TestCase
 
         $logger = $this->createMock(\Taxcloud\Magento2\Logger\Logger::class);
 
-        $complete = new Complete($this->buildScopeConfig('1', CaptureTrigger::ORDER_CREATION), $tcapi, $logger);
+        $complete = new Complete($this->buildScopeConfig('1', CaptureTrigger::ORDER_CREATION), $tcapi, $logger, $this->makeOrderResource());
+        $complete->execute($observer);
+    }
+
+    /**
+     * On a successful capture, the taxcloud_captured flag is set on the order and
+     * persisted via saveAttribute so the cancel flow can read it without OrderDetails.
+     */
+    public function testExecutePersistsCapturedFlagWhenCaptureSucceeds()
+    {
+        $order = $this->buildOrder();
+        $order->expects($this->once())->method('setData')->with('taxcloud_captured', 1);
+        $observer = $this->buildObserver('sales_order_place_after', ['order' => $order]);
+
+        $tcapi = $this->createMock(\Taxcloud\Magento2\Model\Api::class);
+        $tcapi->method('authorizeCapture')->with($order)->willReturn(true);
+
+        $orderResource = $this->createMock(\Magento\Sales\Model\ResourceModel\Order::class);
+        $orderResource->expects($this->once())
+            ->method('saveAttribute')
+            ->with($order, 'taxcloud_captured');
+
+        $logger = $this->createMock(\Taxcloud\Magento2\Logger\Logger::class);
+
+        $complete = new Complete(
+            $this->buildScopeConfig('1', CaptureTrigger::ORDER_CREATION),
+            $tcapi,
+            $logger,
+            $orderResource
+        );
+        $complete->execute($observer);
+    }
+
+    /**
+     * When the capture call fails (returns false), the flag must not be persisted.
+     */
+    public function testExecuteDoesNotPersistFlagWhenCaptureFails()
+    {
+        $order = $this->buildOrder();
+        $observer = $this->buildObserver('sales_order_place_after', ['order' => $order]);
+
+        $tcapi = $this->createMock(\Taxcloud\Magento2\Model\Api::class);
+        $tcapi->method('authorizeCapture')->with($order)->willReturn(false);
+
+        $orderResource = $this->createMock(\Magento\Sales\Model\ResourceModel\Order::class);
+        $orderResource->expects($this->never())->method('saveAttribute');
+
+        $logger = $this->createMock(\Taxcloud\Magento2\Logger\Logger::class);
+
+        $complete = new Complete(
+            $this->buildScopeConfig('1', CaptureTrigger::ORDER_CREATION),
+            $tcapi,
+            $logger,
+            $orderResource
+        );
         $complete->execute($observer);
     }
 
@@ -114,7 +177,7 @@ class CompleteTest extends TestCase
 
         $logger = $this->createMock(\Taxcloud\Magento2\Logger\Logger::class);
 
-        $complete = new Complete($this->buildScopeConfig('1', CaptureTrigger::PAYMENT), $tcapi, $logger);
+        $complete = new Complete($this->buildScopeConfig('1', CaptureTrigger::PAYMENT), $tcapi, $logger, $this->makeOrderResource());
         $complete->execute($observer);
     }
 
@@ -133,7 +196,7 @@ class CompleteTest extends TestCase
 
         $logger = $this->createMock(\Taxcloud\Magento2\Logger\Logger::class);
 
-        $complete = new Complete($this->buildScopeConfig('1', CaptureTrigger::PAYMENT), $tcapi, $logger);
+        $complete = new Complete($this->buildScopeConfig('1', CaptureTrigger::PAYMENT), $tcapi, $logger, $this->makeOrderResource());
         $complete->execute($observer);
     }
 
@@ -153,7 +216,7 @@ class CompleteTest extends TestCase
 
         $logger = $this->createMock(\Taxcloud\Magento2\Logger\Logger::class);
 
-        $complete = new Complete($this->buildScopeConfig('1', CaptureTrigger::SHIPMENT), $tcapi, $logger);
+        $complete = new Complete($this->buildScopeConfig('1', CaptureTrigger::SHIPMENT), $tcapi, $logger, $this->makeOrderResource());
         $complete->execute($observer);
     }
 
@@ -173,7 +236,7 @@ class CompleteTest extends TestCase
 
         $logger = $this->createMock(\Taxcloud\Magento2\Logger\Logger::class);
 
-        $complete = new Complete($this->buildScopeConfig('1', CaptureTrigger::PAYMENT), $tcapi, $logger);
+        $complete = new Complete($this->buildScopeConfig('1', CaptureTrigger::PAYMENT), $tcapi, $logger, $this->makeOrderResource());
         $complete->execute($observer);
     }
 
@@ -193,7 +256,7 @@ class CompleteTest extends TestCase
 
         $logger = $this->createMock(\Taxcloud\Magento2\Logger\Logger::class);
 
-        $complete = new Complete($this->buildScopeConfig('1', CaptureTrigger::SHIPMENT), $tcapi, $logger);
+        $complete = new Complete($this->buildScopeConfig('1', CaptureTrigger::SHIPMENT), $tcapi, $logger, $this->makeOrderResource());
         $complete->execute($observer);
     }
 
@@ -227,7 +290,8 @@ class CompleteTest extends TestCase
             $complete = new Complete(
                 $this->buildScopeConfig('0', CaptureTrigger::ORDER_CREATION),
                 $tcapi,
-                $logger
+                $logger,
+                $this->makeOrderResource()
             );
             $complete->execute($observer);
         }
@@ -260,7 +324,7 @@ class CompleteTest extends TestCase
         $logger->expects($this->never())->method('error');
         $logger->expects($this->never())->method('debug');
 
-        $complete = new Complete($scopeConfig, $tcapi, $logger);
+        $complete = new Complete($scopeConfig, $tcapi, $logger, $this->makeOrderResource());
 
         // Drive execute() through a code path that would normally log
         // (line 121: "Running Observer ..."). The no-op stub must absorb it.
@@ -282,7 +346,7 @@ class CompleteTest extends TestCase
         $logger = $this->createMock(\Taxcloud\Magento2\Logger\Logger::class);
 
         // capture_trigger is null — must default to order_creation
-        $complete = new Complete($this->buildScopeConfig('1', null), $tcapi, $logger);
+        $complete = new Complete($this->buildScopeConfig('1', null), $tcapi, $logger, $this->makeOrderResource());
         $complete->execute($observer);
     }
 }

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Taxcloud_Magento2
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @package    Taxcloud_Magento2
+ * @author     TaxCloud <service@taxcloud.net>
+ * @copyright  2021 The Federal Tax Authority, LLC d/b/a TaxCloud
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+-->
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+    <table name="sales_order">
+        <!-- Set to 1 when the order is successfully captured in TaxCloud. Read on cancel to
+             decide whether to reverse the sale, so the cancel flow does not depend on the
+             license-gated OrderDetails API. -->
+        <column xsi:type="smallint" name="taxcloud_captured" unsigned="true" nullable="true"
+                identity="false" default="0" comment="Order captured in TaxCloud"/>
+    </table>
+</schema>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -1,0 +1,7 @@
+{
+    "sales_order": {
+        "column": {
+            "taxcloud_captured": true
+        }
+    }
+}


### PR DESCRIPTION
### Type of change
- Bug fix

---

### JIRA Ticket: https://taxcloud.atlassian.net/browse/DEV-9171

### Linear: https://linear.app/taxcloud/issue/INT-771

Fixes INT-771

---

### Description

The cancel → `Returned` flow decided whether to reverse a canceled unpaid order by calling the legacy **`OrderDetails`** SOAP API and reading `CapturedDate`. `OrderDetails` is gated behind a per-account license bit in the legacy web service, so any account without that bit hits:

> You do not have a valid TaxCloud API License to use OrderDetails(63148). Please contact TaxCloud to upgrade your License.

`getOrderDetails()` swallows the exception and returns `null`, so there's no hard crash, but the effect is that **canceled captured orders are never reversed in TaxCloud** for those accounts (tax not backed out), and the error is logged noisily.

This change removes the hard dependency on the license-gated API:

- **`etc/db_schema.xml` + whitelist**: add `sales_order.taxcloud_captured` (smallint flag).
- **`Complete` observer**: when `authorizeCapture` succeeds, set `taxcloud_captured = 1` and persist it with `saveAttribute` (single-column write, no full re-save). Failure to persist is non-fatal.
- **`Cancel` observer**: `wasCapturedInTaxcloud()` reads the local flag as the primary signal — no API call, no license needed. `OrderDetails` is kept only as a best-effort fallback for legacy orders placed before the flag existed; when it is unavailable the cancel skips safely instead of erroring.
- **README**: cancel-behavior section updated to describe the local flag + fallback.

Net effect: go-forward orders captured through the plugin never touch `OrderDetails` on cancel, so the license error no longer blocks the reversal. Account 63148 can also be unblocked immediately by enabling the `OrderDetails` license bit (ops stopgap) — the two are independent.

**Note on the migration:** `taxcloud_captured` defaults to `0`, so orders captured *before* this deploys won't have the flag and will use the `OrderDetails` fallback (same as today). This is the pre-install/legacy case the previous design targeted.

---

### TODOs

- [x] Documentation is updated in README
- [x] Tests are added or updated (CompleteTest: flag persisted on capture / not persisted on failure; CancelTest: local-flag path calls Returned without OrderDetails)
- [ ] Verify unit + integration/e2e matrices pass in CI (require Marketplace secrets; run on this main-bound PR)
