### PR TITLE
DEV-9475 Add CODEOWNERS routing to @FedTax/integrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @FedTax/integrations


### PR DESCRIPTION
### Type of change
- DX (Developer Experience)
- Docs

---

### JIRA Ticket: https://taxcloud.atlassian.net/browse/DEV-9475

### Linear: mirrored from DEV-9475 via jira-linear-sync

Closes DEV-9475

---

### Description

Adds a repo-wide `CODEOWNERS` routing all PR reviews to `@FedTax/integrations`, per the Integration Team Working Agreement (reviewer routing is automated via CODEOWNERS). This makes the integration team an automatic review request on every PR in this repo.

- `* @FedTax/integrations`

---

### TODOs
- [ ] Confirm `@FedTax/integrations` is the intended review owner for this repo
