### PR TITLE
1.3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,14 +177,18 @@ jobs:
   # ---------------------------------------------------------------------------
   # Integration tests — community + enterprise across the full version matrix.
   # EXPENSIVE (10-15 min/row, real Magento install in Docker). Runs on release
-  # tags, manual dispatch, and PRs into main (so a main-bound PR is gated by the
-  # same checks as a release tag); skipped on branch pushes and PRs into other
-  # branches.
+  # tags, manual dispatch, and EVERY pull request whatever it targets.
+  #
+  # This used to be limited to PRs into main, which meant work merged into a
+  # release branch first — the normal route for this repo — reached main already
+  # merged and only then got its first integration run. A bundle-tax defect that
+  # only a real Magento quote could expose shipped that way. Branch pushes are
+  # still skipped: the PR is the gate, and a push to a PR branch re-runs it.
   # ---------------------------------------------------------------------------
   integration:
     name: Integration — ${{ matrix.magento-edition }} ${{ matrix.magento-version }} / PHP ${{ matrix.php-version }}
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.base_ref == 'main')
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -300,7 +304,7 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # E2E tests — Playwright against a real, served storefront. Same matrix and
-  # gating as integration (release tags + manual dispatch + PRs into main). Shares the
+  # gating as integration (release tags + manual dispatch + every PR). Shares the
   # install script via E2E=1, which overlays docker-compose.e2e.yml (adds nginx
   # and runs php-fpm) so Magento is reachable over HTTP. The browser runs on the
   # runner and drives the published port. See docs/E2E_TESTS.md.
@@ -308,7 +312,7 @@ jobs:
   e2e:
     name: E2E — ${{ matrix.magento-edition }} ${{ matrix.magento-version }} / PHP ${{ matrix.php-version }}
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.base_ref == 'main')
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
     timeout-minutes: 45
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the TaxCloud Magento 2 extension are documented here.
 
+## 1.3.1
+
+### Fixed
+
+- **Bundle products with dynamic pricing were taxed on a fraction of their
+  value.** A bundle's selections store their quantity per bundle — one unit
+  inside a qty-2 bundle is stored as 1, against a row total for 2 — and the
+  tax lookup sent that stored number. A qty-2 bundle was therefore taxed as
+  one, a qty-3 bundle as one of three, and the shopper was undercharged by the
+  difference. Bundle lines now carry the quantity their row total was built
+  from. Configurable, grouped, simple and fixed-price bundle products were
+  never affected.
+- **A bundle's value was reported to TaxCloud twice.** The lookup sent both the
+  bundle line and each of its selections, so the transaction recorded against
+  the order — and captured with it — covered more than the order was worth,
+  while Magento (which excludes the bundle wrapper from its own totals by
+  design) charged less. Returns and cancellations described the same order
+  differently again. All three now describe a bundle the same way: by its
+  selections, which are the lines that carry its price.
+
+  Orders placed with a dynamic-price bundle before this release were charged
+  and reported incorrectly and are not corrected by updating; they need
+  adjusting in TaxCloud.
+- **Refunds named items the order never reported.** A credit memo lists a
+  composite's children alongside their parent, so refunding a configurable or a
+  fixed-price bundle returned its selections as extra $0 lines — item IDs that
+  were never in the original lookup. No tax rode on them, but the three payloads
+  for one order each described it differently, which is the condition the bundle
+  defect above hid inside. All three now name the same lines.
+- A cart line at quantity zero no longer raises a division-by-zero error while
+  its discount is being apportioned.
+
 ## 1.3.0
 
 Run `bin/magento setup:upgrade` after updating: this release adds a category

--- a/Model/CompositeItemResolver.php
+++ b/Model/CompositeItemResolver.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Taxcloud_Magento2
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ *
+ * @package    Taxcloud_Magento2
+ * @author     TaxCloud <service@taxcloud.net>
+ * @copyright  2021 The Federal Tax Authority, LLC d/b/a TaxCloud
+ * @license    http://opensource.org/licenses/osl-3.0.php Open Software License (OSL 3.0)
+ */
+
+namespace Taxcloud\Magento2\Model;
+
+/**
+ * Decides how a composite product (bundle, configurable, grouped) becomes
+ * TaxCloud cart lines.
+ *
+ * Magento splits a composite line one of two ways, chosen by the product's
+ * price type:
+ *
+ *  - CALCULATE_CHILD — a *dynamic-price* bundle. The children carry the price
+ *    and the whole taxable basis; the parent is a wrapper that Magento
+ *    deliberately leaves out of the address totals (see the "avoid double
+ *    counting" branch in CommonTaxCollector::processProductItems). Sending
+ *    both the parent and its children reports that basis to TaxCloud twice.
+ *  - CALCULATE_PARENT — a configurable, or a fixed-price bundle. The parent
+ *    carries the price and the children are priced at 0. Only the parent is
+ *    mapped into the tax details, so nothing here applies.
+ *
+ * A dynamic-price bundle is the only thing that reaches the first case: the
+ * price type behind it is a bundle-only attribute, and configurables are the
+ * only other type that records a calculation mode, always as CALCULATE_PARENT.
+ * Grouped products explode into one independent line per associated product,
+ * and virtual, downloadable and gift card products are not composite at all —
+ * all of them arrive as ordinary childless lines carrying their own price and
+ * their own absolute quantity. Any of them can still be a *selection* inside a
+ * dynamic bundle, which is why the rule keys on the bundle and not on the type
+ * of what it holds.
+ *
+ * The trap this class exists to contain is that the two halves of the order
+ * lifecycle store a child's quantity on *different scales*:
+ *
+ *  - a QUOTE child stores qty per parent — one unit of a selection inside a
+ *    qty-2 bundle is stored as 1 — while its row total is already
+ *    parent-multiplied ($20 for a $10 selection). Magento reconciles the two
+ *    in TaxCalculation::getTotalQuantity(); anything sending a quote child to
+ *    a tax service has to do the same, or it prices one unit and bills for two.
+ *  - an ORDER or credit-memo child stores the absolute qty — that same line is
+ *    stored as qty_ordered 2.
+ *
+ * So: multiply on the quote side, never on the order side.
+ */
+class CompositeItemResolver
+{
+    /**
+     * True when this quote item's children carry the taxable basis, which makes
+     * the item itself a wrapper that must not become a cart line of its own.
+     *
+     * @param \Magento\Quote\Model\Quote\Item\AbstractItem $item
+     * @return bool
+     */
+    public static function isQuoteParentPricedByChildren($item)
+    {
+        if (!$item || $item->getParentItem()) {
+            return false;
+        }
+
+        $children = $item->getChildren();
+
+        // isChildrenCalculated() is the same test Magento's own mapItems() uses
+        // to decide whether to map the children as separate tax-detail rows, so
+        // a parent that passes it always has its children in the details too.
+        return !empty($children) && $item->isChildrenCalculated();
+    }
+
+    /**
+     * The quantity a quote item actually represents: for a child of a
+     * dynamic-price bundle that is its per-parent qty times the parent's.
+     *
+     * Mirrors \Magento\Tax\Model\TaxCalculation::getTotalQuantity(), which is
+     * what produced the row total this quantity has to agree with.
+     *
+     * @param \Magento\Quote\Model\Quote\Item\AbstractItem $item
+     * @return float
+     */
+    public static function quoteQty($item)
+    {
+        $qty = (float) $item->getQty();
+        $parent = $item->getParentItem();
+
+        return $parent ? $qty * (float) $parent->getQty() : $qty;
+    }
+
+    /**
+     * Order-side counterpart of isQuoteParentPricedByChildren(): true when this
+     * order item is a dynamic-price bundle whose children carry the basis.
+     *
+     * Reads product_options['product_calculations'], persisted on the parent at
+     * order placement, so it stays correct for an order loaded years later —
+     * long after the product's price type may have been edited in the catalog.
+     *
+     * @param \Magento\Sales\Model\Order\Item $item
+     * @return bool
+     */
+    public static function isOrderParentPricedByChildren($item)
+    {
+        if (!$item || $item->getParentItemId()) {
+            return false;
+        }
+
+        return (bool) $item->isChildrenCalculated();
+    }
+
+    /**
+     * True when this order item is a child whose parent carries the price — a
+     * configurable's simple, or a fixed-price bundle's selection.
+     *
+     * Such a child is priced at 0 and never becomes a cart line: the Lookup
+     * derives its lines from the visible items, so sending the child on a refund
+     * would return an item ID the order never reported selling. It costs nothing
+     * in tax, being worth nothing, but it makes the three payloads describe the
+     * same order differently — and that divergence is what hid the bundle defect.
+     *
+     * @param \Magento\Sales\Model\Order\Item $item
+     * @return bool
+     */
+    public static function isOrderChildWithoutBasis($item)
+    {
+        return $item && $item->getParentItemId() && !$item->isChildrenCalculated();
+    }
+
+    /**
+     * The order items that carry the taxable basis for a top-level order item:
+     * the item itself, or the children of a dynamic-price bundle.
+     *
+     * Falls back to the item itself when such a bundle has no children linked —
+     * an over-report is recoverable, a silently untaxed line is not.
+     *
+     * @param \Magento\Sales\Model\Order\Item $item
+     * @return \Magento\Sales\Model\Order\Item[]
+     */
+    public static function orderBasisItems($item)
+    {
+        if (!self::isOrderParentPricedByChildren($item)) {
+            return [$item];
+        }
+
+        $children = $item->getChildrenItems();
+
+        return empty($children) ? [$item] : array_values($children);
+    }
+}

--- a/Model/Fallback/MagentoTaxFallback.php
+++ b/Model/Fallback/MagentoTaxFallback.php
@@ -25,6 +25,7 @@ use Magento\Tax\Api\Data\TaxClassKeyInterfaceFactory;
 use Magento\Tax\Api\TaxCalculationInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Taxcloud\Magento2\Model\CompositeItemResolver;
 
 /**
  * Computes tax using Magento's native tax engine as a fallback when a TaxCloud
@@ -132,6 +133,10 @@ class MagentoTaxFallback
             $quoteDetails->setCustomerTaxClassId($quote->getCustomerTaxClassId());
             $quoteDetails->setItems([]);
 
+            // Typed as core types them (CommonTaxCollector::processProductItems):
+            // a shipping assignment's items are quote items, and the composite
+            // accessors below live on AbstractItem, not CartItemInterface.
+            /** @var \Magento\Quote\Model\Quote\Item\AbstractItem[] $keyedAddressItems */
             $keyedAddressItems = [];
             foreach ($shippingAssignment->getItems() as $item) {
                 // Skip composite child lines with no tax calculation id (null
@@ -160,6 +165,13 @@ class MagentoTaxFallback
                     if ($item->getProduct()->getTaxClassId() === '0') {
                         continue;
                     }
+                    // Dynamic-price bundle wrapper: its children are items of
+                    // their own below and carry the basis. These details are a
+                    // flat list with no parent codes, so Magento's own
+                    // TaxCalculation cannot tell the two apart on its own.
+                    if (CompositeItemResolver::isQuoteParentPricedByChildren($item)) {
+                        continue;
+                    }
 
                     $quoteDetailsItem = $this->quoteDetailsItemFactory->create();
                     $quoteDetailsItem->setCode($code);
@@ -169,7 +181,9 @@ class MagentoTaxFallback
                     $taxClassKey->setValue($item->getProduct()->getTaxClassId());
                     $quoteDetailsItem->setTaxClassKey($taxClassKey);
                     $quoteDetailsItem->setUnitPrice($item->getPrice());
-                    $quoteDetailsItem->setQuantity($item->getQty());
+                    // Parent-multiplied for a bundle child, matching the row
+                    // total — the same reconciliation the live lookup makes.
+                    $quoteDetailsItem->setQuantity(CompositeItemResolver::quoteQty($item));
                     $quoteDetailsItem->setDiscountAmount($item->getDiscountAmount());
                     $quoteDetailsItem->setIsTaxIncluded(false);
 

--- a/Model/Gateway/RequestBuilder.php
+++ b/Model/Gateway/RequestBuilder.php
@@ -22,6 +22,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Taxcloud\Magento2\Model\CompositeItemResolver;
 use Taxcloud\Magento2\Model\Config\TaxcloudConfig;
 use Taxcloud\Magento2\Model\PostalCodeParser;
 use Taxcloud\Magento2\Model\ProductTicService;
@@ -215,12 +216,24 @@ class RequestBuilder
                     // Skip products with tax_class_id of None, store owners should avoid doing this
                     continue;
                 }
+                if (CompositeItemResolver::isQuoteParentPricedByChildren($item)) {
+                    // Dynamic-price bundle: the children below carry this line's
+                    // whole basis and are cart lines of their own. Sending the
+                    // parent as well would report that basis to TaxCloud twice.
+                    continue;
+                }
+
+                // Not getQty(): a bundle child stores its qty per parent, so the
+                // effective qty is what the row total was built from.
+                $qty = CompositeItemResolver::quoteQty($item);
+                $discountPerUnit = $qty > 0 ? $item->getDiscountAmount() / $qty : 0;
+
                 $cartItems[] = [
                     'ItemID' => $item->getSku(),
                     'Index' => $index,
                     'TIC' => $this->productTicService->getProductTic($item, 'lookupTaxes', $store),
-                    'Price' => $item->getPrice() - $item->getDiscountAmount() / $item->getQty(),
-                    'Qty' => $item->getQty(),
+                    'Price' => $item->getPrice() - $discountPerUnit,
+                    'Qty' => $qty,
                 ];
                 $indexedItems[$index++] = $code;
             }
@@ -307,6 +320,21 @@ class RequestBuilder
                     continue;
                 }
                 $item = $creditItem->getOrderItem();
+                // A credit memo lists parents and children alike, so both halves
+                // of a composite have to be filtered to leave exactly the lines
+                // that carry the basis — the same ones the Lookup sent.
+                //
+                // Dynamic-price bundle parent: its children are credit-memo items
+                // of their own and carry the basis. Unlike the quote side, their
+                // qty is already absolute — do not multiply it here.
+                if (CompositeItemResolver::isOrderParentPricedByChildren($item)) {
+                    continue;
+                }
+                // Configurable or fixed-bundle child: the parent above carries
+                // the price and this line is worth 0.
+                if (CompositeItemResolver::isOrderChildWithoutBasis($item)) {
+                    continue;
+                }
                 $price = $creditItem->getPrice();
                 $discountPerUnit = $qty > 0 ? $creditItem->getDiscountAmount() / $qty : 0;
                 $cartItems[] = [
@@ -380,22 +408,27 @@ class RequestBuilder
         $index = 0;
         $orderItems = $order->getAllVisibleItems();
         if ($orderItems) {
-            foreach ($orderItems as $item) {
-                $qty = (float) $item->getQtyOrdered();
-                if ($qty <= 0) {
-                    continue;
+            foreach ($orderItems as $visibleItem) {
+                // A dynamic-price bundle is visible as its parent, but the basis
+                // lives on its children — and those are the lines the Lookup for
+                // this order sent, so a return has to name the same ones.
+                foreach (CompositeItemResolver::orderBasisItems($visibleItem) as $item) {
+                    $qty = (float) $item->getQtyOrdered();
+                    if ($qty <= 0) {
+                        continue;
+                    }
+                    $price = (float) $item->getPrice();
+                    $discountAmount = (float) $item->getDiscountAmount();
+                    $discountPerUnit = $qty > 0 ? $discountAmount / $qty : 0;
+                    $cartItems[] = [
+                        'ItemID' => $item->getSku(),
+                        'Index' => $index,
+                        'TIC' => $this->productTicService->getProductTic($item, 'returnOrder', $store),
+                        'Price' => $price - $discountPerUnit,
+                        'Qty' => $qty,
+                    ];
+                    $index++;
                 }
-                $price = (float) $item->getPrice();
-                $discountAmount = (float) $item->getDiscountAmount();
-                $discountPerUnit = $qty > 0 ? $discountAmount / $qty : 0;
-                $cartItems[] = [
-                    'ItemID' => $item->getSku(),
-                    'Index' => $index,
-                    'TIC' => $this->productTicService->getProductTic($item, 'returnOrder', $store),
-                    'Price' => $price - $discountPerUnit,
-                    'Qty' => $qty,
-                ];
-                $index++;
             }
         }
         $shippingAmount = (float) $order->getBaseShippingAmount();

--- a/Model/Tax.php
+++ b/Model/Tax.php
@@ -129,6 +129,10 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
         // Fetch tax amount from TaxCloud
         $taxAmounts = $this->tcapi->lookupTaxes($itemsByType, $shippingAssignment, $quote);
 
+        // Typed as core types them (CommonTaxCollector::processProductItems):
+        // a shipping assignment's items are quote items, and the composite
+        // accessors below live on AbstractItem rather than CartItemInterface.
+        /** @var \Magento\Quote\Model\Quote\Item\AbstractItem[] $keyedAddressItems */
         $keyedAddressItems = [];
         foreach ($shippingAssignment->getItems() as $item) {
             // Configurable/composite lines expose a child item with no tax
@@ -151,21 +155,36 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
 
                 $quoteItem = $keyedAddressItems[$code];
 
-                if ($quoteItem->getProduct()->getTaxClassId() === '0' || $quoteItem->getQty() === 0) {
+                // A bundle child's qty is stored per parent while its row total
+                // is already parent-multiplied; CompositeItemResolver reconciles
+                // the two the same way the Lookup request does.
+                $effectiveQty = CompositeItemResolver::quoteQty($quoteItem);
+                $isPricedByChildren = CompositeItemResolver::isQuoteParentPricedByChildren($quoteItem);
+
+                if ($quoteItem->getProduct()->getTaxClassId() === '0' || $effectiveQty <= 0) {
                     $taxAmount = 0;
                     $taxAmountPer = 0;
+                } elseif ($isPricedByChildren) {
+                    // Never sent to TaxCloud, so it has no amount of its own: show
+                    // the sum of its children, which is the tax this line bears.
+                    $taxAmount = $this->sumChildTaxAmounts($quoteItem, $taxAmounts);
+                    $taxAmountPer = $taxAmount / $effectiveQty;
                 } else {
                     $taxAmount = $taxAmounts[self::ITEM_TYPE_PRODUCT][$code] ?? 0;
-                    $taxAmountPer = $taxAmount / $quoteItem->getQty();
+                    $taxAmountPer = $taxAmount / $effectiveQty;
                 }
 
-                $productTaxTotal += (float) $taxAmount;
+                if (!$isPricedByChildren) {
+                    // The parent's amount is an echo of its children's, and core
+                    // keeps it out of the address total for the same reason.
+                    $productTaxTotal += (float) $taxAmount;
+                }
 
                 // Snapshot pre-tax values on first collect; reuse on subsequent passes.
                 // Without this, any 3rd-party collector that mutates getPrice()/getRowTotal()
                 // between collect() invocations causes incl-tax to compound (see order #2000543282).
                 // Snapshot invalidates on qty change so genuine cart edits are picked up.
-                $currentQty = (float) $quoteItem->getQty();
+                $currentQty = $effectiveQty;
                 if ($quoteItem->getData('taxcloud_pretax_price') === null
                     || (float) $quoteItem->getData('taxcloud_pretax_qty') !== $currentQty
                 ) {
@@ -283,5 +302,30 @@ class Tax extends \Magento\Tax\Model\Sales\Total\Quote\Tax
         }
 
         return $this;
+    }
+
+    /**
+     * Total the looked-up tax of a quote item's children.
+     *
+     * The tax a dynamic-price bundle's parent line displays: it is not sent to
+     * TaxCloud itself, so this is the only amount it can honestly carry.
+     *
+     * @param \Magento\Quote\Model\Quote\Item\AbstractItem $quoteItem
+     * @param array $taxAmounts Lookup amounts keyed by tax-calculation item id
+     * @return float
+     */
+    private function sumChildTaxAmounts($quoteItem, array $taxAmounts)
+    {
+        $sum = 0.0;
+
+        foreach ($quoteItem->getChildren() as $child) {
+            $childCode = $child->getTaxCalculationItemId();
+            if ($childCode === null) {
+                continue;
+            }
+            $sum += (float) ($taxAmounts[self::ITEM_TYPE_PRODUCT][$childCode] ?? 0);
+        }
+
+        return $sum;
     }
 }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## Compatibility
 
 **Adobe Commerce 2.4.9 Compatible** ✅  
-This extension (Version 1.3.0) is tested and verified against Adobe Commerce
+This extension (Version 1.3.1) is tested and verified against Adobe Commerce
 2.4.7-p10, 2.4.8-p5 and 2.4.9 — the unit, integration and E2E suites run on all
 three on every change.
 

--- a/Test/E2E/pages/storefront/ProductPage.ts
+++ b/Test/E2E/pages/storefront/ProductPage.ts
@@ -7,11 +7,17 @@ import { type Page, type Locator, expect } from '@playwright/test';
 export class ProductPage {
   readonly page: Page;
   readonly addToCartButton: Locator;
+  readonly customizeButton: Locator;
+  readonly qtyInput: Locator;
   readonly successMessage: Locator;
 
   constructor(page: Page) {
     this.page = page;
     this.addToCartButton = page.locator('#product-addtocart-button');
+    // Bundles open on a summary view; the options (and the real Add to Cart)
+    // are behind this button.
+    this.customizeButton = page.locator('#bundle-slide');
+    this.qtyInput = page.locator('#qty');
     this.successMessage = page.locator('.message-success').first();
   }
 
@@ -29,6 +35,66 @@ export class ProductPage {
 
   /** Click "Add to Cart" and wait for the confirmation message. */
   async addToCart(): Promise<void> {
+    await this.addToCartButton.click();
+    await expect(this.successMessage).toBeVisible({ timeout: 30_000 });
+  }
+
+  /** Set the quantity before adding. */
+  async setQty(qty: number): Promise<void> {
+    await this.qtyInput.fill(String(qty));
+  }
+
+  /**
+   * Choose a configurable variant by its option label ("Red").
+   *
+   * Selected by label rather than value: the attribute id and its option value
+   * indexes are assigned at install time, so anything keyed on them would pass
+   * on the box it was written against and nowhere else.
+   */
+  async selectVariant(label: string): Promise<void> {
+    const select = this.page.locator('select.super-attribute-select').first();
+    await expect(select).toBeVisible({ timeout: 30_000 });
+    await select.selectOption({ label });
+  }
+
+  /**
+   * Set the quantity of each associated product on a grouped PDP.
+   *
+   * Magento pre-fills these from the link quantities, so a grouped product can
+   * be added untouched — but setting them explicitly is what proves each
+   * association becomes its own line at its own quantity.
+   */
+  async setGroupedQuantities(quantities: number[]): Promise<void> {
+    const inputs = this.page.locator('input[name^="super_group"]');
+    await expect(inputs.first()).toBeVisible({ timeout: 30_000 });
+
+    const count = await inputs.count();
+    for (let i = 0; i < Math.min(count, quantities.length); i++) {
+      await inputs.nth(i).fill(String(quantities[i]));
+    }
+  }
+
+  /**
+   * Add a bundle, revealing its options first.
+   *
+   * The seeded bundles have every selection default-checked, so no choosing is
+   * needed — but the fieldset still has to be open, because the qty box and the
+   * live Add to Cart button live inside it.
+   */
+  async addBundleToCart(qty?: number): Promise<void> {
+    // "Customize and Add to Cart" only opens the options once RequireJS has
+    // bound its handler, which happens after the load event Playwright waits
+    // for. Clicking before that is a no-op that looks exactly like a broken
+    // page, so retry the click until the options actually open.
+    await expect(async () => {
+      await this.customizeButton.click();
+      await expect(this.addToCartButton).toBeVisible({ timeout: 3_000 });
+    }).toPass({ timeout: 30_000 });
+
+    if (qty !== undefined) {
+      await this.qtyInput.fill(String(qty));
+    }
+
     await this.addToCartButton.click();
     await expect(this.successMessage).toBeVisible({ timeout: 30_000 });
   }

--- a/Test/E2E/specs/checkout/catalog-types-checkout.spec.ts
+++ b/Test/E2E/specs/checkout/catalog-types-checkout.spec.ts
@@ -1,0 +1,234 @@
+import { test, expect } from '@playwright/test';
+import { ProductPage } from '../../pages/storefront/ProductPage';
+import { CheckoutPage, type GuestAddress } from '../../pages/storefront/CheckoutPage';
+
+/**
+ * A.4 — What the customer is charged for a composite cart.
+ *
+ * The integration suite proves what reaches TaxCloud and what lands in the
+ * database. This proves the last mile: the number in the checkout summary, for
+ * the cart shapes where that number was wrong.
+ *
+ * Deliberately thin. A per-type matrix belongs in the integration suite, which
+ * runs in seconds against a mocked SOAP client; every scenario here makes live
+ * TaxCloud calls through a real browser, so it earns its place only by covering
+ * something the layers below cannot see.
+ *
+ * REAL SERVICES, no SOAP mock — same contract as the other specs in this folder.
+ * Rather than pin a golden total (which a rate change would break, and which
+ * per-line cent rounding makes fiddly to predict on a multi-line cart), these
+ * assert the RATE against the taxed base. That is what the bundle defect broke:
+ * the customer was charged a third of the correct tax, which no tolerance hides.
+ */
+
+// In-state with the seeded Austin TX origin, so the rate is the local one.
+const TX_ADDRESS: GuestAddress = {
+  email: 'guest@example.com',
+  firstname: 'Test',
+  lastname: 'Buyer',
+  street: '1401 Lavaca St',
+  city: 'Austin',
+  region: 'Texas',
+  postcode: '78701',
+  telephone: '5125550100',
+};
+
+/** Austin TX combined rate for the seeded origin/destination. */
+const RATE = 0.0825;
+
+/** Per-line cent rounding means the total can drift a few cents from rate x base. */
+const CENTS_TOLERANCE = 0.05;
+
+const money = (s: string): number => parseFloat(s.replace(/[^0-9.]/g, ''));
+
+/**
+ * The whole point of the bundle fix, seen from the customer's side.
+ *
+ * The seeded dynamic bundle is $30 of selections (1 x $10 + 2 x $10). Three of
+ * them is $90 of goods. Before the fix TaxCloud was told about one unit of each
+ * selection, so the customer was billed tax on $30 and the store quietly ate the
+ * difference — a shortfall far larger than any rounding tolerance.
+ */
+test('a multi-quantity dynamic bundle is taxed on the whole cart', async ({ page }) => {
+  test.setTimeout(180_000);
+
+  const product = new ProductPage(page);
+  const checkout = new CheckoutPage(page);
+
+  await product.open('test-bundle-dynamic');
+  await product.addBundleToCart(3);
+
+  await checkout.open();
+  await checkout.fillGuestShipping(TX_ADDRESS);
+  await checkout.selectFlatRateAndContinue();
+
+  const subtotal = money(await checkout.subtotal.innerText());
+  const shipping = money(await checkout.shipping.innerText());
+  const tax = money(await checkout.tax.innerText());
+  const grand = money(await checkout.grandTotal.innerText());
+
+  // Three bundles of $30 of selections.
+  expect(subtotal).toBeCloseTo(90, 2);
+
+  // The assertion that fails loudly on the regression: a third of this is 2.48.
+  expect(tax).toBeCloseTo((subtotal + shipping) * RATE, 1);
+  expect(tax).toBeGreaterThan((subtotal + shipping) * RATE - CENTS_TOLERANCE);
+
+  expect(grand).toBeCloseTo(subtotal + shipping + tax, 2);
+
+  await checkout.selectCheckMoneyOrder();
+  await checkout.placeOrder();
+  await expect(checkout.successBlock).toContainText('Your order # is:');
+});
+
+/**
+ * Several catalog types in one cart, which is how a real order arrives.
+ *
+ * Each type contributes its lines through different code, and a cart mixing them
+ * is the case where one type's handling can quietly corrupt another's total.
+ */
+test('a cart mixing catalog types is taxed on every line', async ({ page }) => {
+  test.setTimeout(180_000);
+
+  const product = new ProductPage(page);
+  const checkout = new CheckoutPage(page);
+
+  await product.open('test-product');
+  await product.addToCart();
+
+  await product.open('test-bundle-fixed');
+  await product.addBundleToCart();
+
+  await product.open('test-downloadable');
+  await product.addToCart();
+
+  await checkout.open();
+  await checkout.fillGuestShipping(TX_ADDRESS);
+  await checkout.selectFlatRateAndContinue();
+
+  const subtotal = money(await checkout.subtotal.innerText());
+  const shipping = money(await checkout.shipping.innerText());
+  const tax = money(await checkout.tax.innerText());
+  const grand = money(await checkout.grandTotal.innerText());
+
+  // $10 simple + $50 fixed bundle + $10 downloadable.
+  expect(subtotal).toBeCloseTo(70, 2);
+
+  expect(tax).toBeCloseTo((subtotal + shipping) * RATE, 1);
+  expect(grand).toBeCloseTo(subtotal + shipping + tax, 2);
+
+  await checkout.selectCheckMoneyOrder();
+  await checkout.placeOrder();
+  await expect(checkout.successBlock).toContainText('Your order # is:');
+});
+
+/**
+ * A configurable is taxed on the variant the shopper chose, not on the parent.
+ *
+ * The seeded Red variant carries its own TIC (20010) while the parent carries
+ * none, so this also exercises the TIC travelling from the chosen simple —
+ * ConfigurableProductVariantTicTest asserts that in the payload, and this
+ * asserts the shopper is charged accordingly.
+ */
+test('a configurable is taxed on the chosen variant', async ({ page }) => {
+  test.setTimeout(180_000);
+
+  const product = new ProductPage(page);
+  const checkout = new CheckoutPage(page);
+
+  await product.open('test-configurable');
+  await product.selectVariant('Red');
+  await product.setQty(2);
+  await product.addToCart();
+
+  await checkout.open();
+  await checkout.fillGuestShipping(TX_ADDRESS);
+  await checkout.selectFlatRateAndContinue();
+
+  const subtotal = money(await checkout.subtotal.innerText());
+  const shipping = money(await checkout.shipping.innerText());
+  const tax = money(await checkout.tax.innerText());
+  const grand = money(await checkout.grandTotal.innerText());
+
+  expect(subtotal).toBeCloseTo(20, 2);
+  expect(tax).toBeCloseTo((subtotal + shipping) * RATE, 1);
+  expect(grand).toBeCloseTo(subtotal + shipping + tax, 2);
+
+  await checkout.selectCheckMoneyOrder();
+  await checkout.placeOrder();
+  await expect(checkout.successBlock).toContainText('Your order # is:');
+});
+
+/**
+ * A grouped product is not one line but several.
+ *
+ * Magento never puts the grouped product itself in the cart: each association
+ * becomes an independent line at its own quantity. Two associations at
+ * different quantities is the case that would expose any attempt to treat the
+ * group as a composite with a shared parent.
+ */
+test('a grouped product is taxed as its associated lines', async ({ page }) => {
+  test.setTimeout(180_000);
+
+  const product = new ProductPage(page);
+  const checkout = new CheckoutPage(page);
+
+  await product.open('test-grouped');
+  // 2 x Test Product ($10) + 1 x Test Virtual ($10).
+  await product.setGroupedQuantities([2, 1]);
+  await product.addToCart();
+
+  await checkout.open();
+  await checkout.fillGuestShipping(TX_ADDRESS);
+  await checkout.selectFlatRateAndContinue();
+
+  const subtotal = money(await checkout.subtotal.innerText());
+  const shipping = money(await checkout.shipping.innerText());
+  const tax = money(await checkout.tax.innerText());
+  const grand = money(await checkout.grandTotal.innerText());
+
+  expect(subtotal).toBeCloseTo(30, 2);
+  expect(tax).toBeCloseTo((subtotal + shipping) * RATE, 1);
+  expect(grand).toBeCloseTo(subtotal + shipping + tax, 2);
+
+  await checkout.selectCheckMoneyOrder();
+  await checkout.placeOrder();
+  await expect(checkout.successBlock).toContainText('Your order # is:');
+});
+
+/**
+ * A cart that ships nothing takes a different route through checkout: Magento
+ * drops the shipping step and collects a billing address on the payment step
+ * instead, which is what makes a digital sale source to the billing address.
+ *
+ * This asserts the routing, not the tax. Until a billing address is entered
+ * there is no address to tax against, so the summary shows Cart Subtotal and
+ * Order Total and no tax row at all — reaching one would mean driving the
+ * payment-step billing form, a flow no page object here models yet.
+ *
+ * The tax consequences of that routing are covered where they can be asserted
+ * precisely: CatalogTypeLookupTest proves a virtual-only quote is taxed against
+ * the billing address and that adding a shippable line moves the whole cart to
+ * the shipping address. Digital goods being taxed at all is covered in e2e by
+ * the mixed-cart scenario above, which carries a downloadable line.
+ */
+test('a virtual-only cart checks out with no shipping step', async ({ page }) => {
+  test.setTimeout(120_000);
+
+  const product = new ProductPage(page);
+  const checkout = new CheckoutPage(page);
+
+  await product.open('test-virtual');
+  await product.addToCart();
+
+  await checkout.open();
+
+  // Guest email is collected on the one and only step.
+  await expect(checkout.email).toBeVisible({ timeout: 60_000 });
+
+  const steps = page.locator('.opc-progress-bar-item');
+  await expect(steps).toHaveCount(1);
+  await expect(steps.first()).toContainText('Review & Payments');
+
+  expect(money(await checkout.subtotal.innerText())).toBeCloseTo(10, 2);
+});

--- a/Test/Integration/Model/Tax/CatalogTypeLifecycleTest.php
+++ b/Test/Integration/Model/Tax/CatalogTypeLifecycleTest.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * Taxcloud_Magento2
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ */
+
+namespace Taxcloud\Magento2\Test\Integration\Model\Tax;
+
+use Magento\Framework\DataObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Magento\Quote\Api\CartManagementInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\CreditmemoFactory;
+use Magento\Sales\Model\Service\CreditmemoService;
+use Taxcloud\Magento2\Test\Integration\IntegrationTestCase;
+use Taxcloud\Magento2\Test\Integration\SeededCatalogTrait;
+
+/**
+ * An order of each catalog type from checkout to refund.
+ *
+ * Every stage of the lifecycle builds its payload from a different source — the
+ * quote, then the order's visible items, then the credit memo's items — and each
+ * source stores a composite differently. Coverage of one stage says nothing about
+ * the others, which is how an order came to be authorized for $70 of goods,
+ * charged for $50 worth of tax basis, and refundable for something else again.
+ *
+ * Beyond the composites, virtual and downloadable are here because they are the
+ * types that produce a VIRTUAL order: no shipping address at all, so capture and
+ * refund read totals from the billing address instead. That is a different route
+ * through the same code, and the shape most likely to be missed.
+ *
+ * Gift card is absent: its module ships only with Adobe Commerce, and a row here
+ * would skip on every Open Source run rather than cover anything.
+ */
+class CatalogTypeLifecycleTest extends IntegrationTestCase
+{
+    use SeededCatalogTrait;
+
+    private const RATE = 0.10;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->installSoapMock($this->soapResponsesWith([
+            'lookup' => $this->flatRateLookupResponder(self::RATE),
+        ]));
+    }
+
+    /**
+     * @return array<string, array{sku: string, qty: int, expected: array<int, array{0: string, 1: float, 2: float}>}>
+     */
+    public static function catalogTypeProvider(): array
+    {
+        return [
+            'bundle dynamic' => [
+                'sku' => 'test-bundle-dynamic',
+                'qty' => 2,
+                'expected' => [['test-product', 2.0, 10.0], ['test-virtual', 4.0, 10.0]],
+            ],
+            'bundle fixed' => [
+                'sku' => 'test-bundle-fixed',
+                'qty' => 2,
+                'expected' => [['test-bundle-fixed', 2.0, 50.0]],
+            ],
+            'configurable' => [
+                'sku' => 'test-configurable',
+                'qty' => 2,
+                'expected' => [['test-variant-red', 2.0, 10.0]],
+            ],
+            'grouped' => [
+                'sku' => 'test-grouped',
+                'qty' => 2,
+                'expected' => [['test-product', 2.0, 10.0], ['test-virtual', 2.0, 10.0]],
+            ],
+            // Neither of these ships, so each makes a VIRTUAL order: no shipping
+            // address, totals collected against billing, and a different route
+            // through capture and refund than everything above.
+            'virtual' => [
+                'sku' => 'test-virtual',
+                'qty' => 2,
+                'expected' => [['test-virtual', 2.0, 10.0]],
+            ],
+            'downloadable' => [
+                'sku' => 'test-downloadable',
+                'qty' => 2,
+                'expected' => [['test-downloadable', 2.0, 10.0]],
+            ],
+        ];
+    }
+
+    /**
+     * Capturing books the Lookup by cart id, so whatever the Lookup said is what
+     * the store is on the hook for. This asserts the Lookup said the right thing
+     * and that capture really did fire against that order.
+     *
+     * @dataProvider catalogTypeProvider
+     */
+    #[DataProvider('catalogTypeProvider')]
+    public function testCaptureBooksTheLinesTheLookupReported(string $sku, int $qty, array $expected): void
+    {
+        $order = $this->placeOrderFor($sku, $qty);
+        $soap = $this->soapClient();
+
+        $this->assertSame(
+            $expected,
+            $this->productLines($soap->firstCallArgs('lookup')['cartItems'] ?? []),
+            "The lookup for $sku does not describe the order."
+        );
+
+        $this->assertSame(
+            1,
+            $soap->callCount('authorizedWithCapture'),
+            "Placing a $sku order should capture it exactly once."
+        );
+        $this->assertSame(
+            $order->getIncrementId(),
+            $soap->firstCallArgs('authorizedWithCapture')['orderID'] ?? null,
+            'The captured order id should be this order.'
+        );
+    }
+
+    /**
+     * Cancelling an uncaptured order reverses it from the order's own items
+     * rather than a credit memo — a third code path over the same composite.
+     *
+     * @dataProvider catalogTypeProvider
+     */
+    #[DataProvider('catalogTypeProvider')]
+    public function testCancelReversesTheLinesTheLookupReported(string $sku, int $qty, array $expected): void
+    {
+        $order = $this->placeOrderFor($sku, $qty);
+        $soap = $this->soapClient();
+        $soap->resetCalls();
+
+        $this->cancelOrder($order);
+
+        $this->assertSame(
+            1,
+            $soap->callCount('Returned'),
+            "Cancelling a captured $sku order should reverse it exactly once."
+        );
+        $this->assertSame(
+            $expected,
+            $this->productLines($soap->firstCallArgs('Returned')['cartItems'] ?? []),
+            "Cancelling $sku reverses different goods than were reported at checkout."
+        );
+    }
+
+    /**
+     * A full refund, from the credit memo path.
+     *
+     * @dataProvider catalogTypeProvider
+     */
+    #[DataProvider('catalogTypeProvider')]
+    public function testFullRefundReturnsTheWholeOrder(string $sku, int $qty, array $expected): void
+    {
+        $order = $this->placeOrderFor($sku, $qty);
+        $this->payInvoice($order);
+
+        $soap = $this->soapClient();
+        $soap->resetCalls();
+
+        $this->refundOrder($order);
+
+        $this->assertSame(
+            $expected,
+            $this->productLines($soap->firstCallArgs('Returned')['cartItems'] ?? []),
+            "The full refund of $sku returns different goods than the order reported."
+        );
+    }
+
+    /**
+     * Refunding half the order must return half the goods — and for a composite
+     * that means halving the quantity Magento derived for each selection, not the
+     * one stored against it.
+     *
+     * @dataProvider catalogTypeProvider
+     */
+    #[DataProvider('catalogTypeProvider')]
+    public function testPartialRefundReturnsProportionalQuantities(string $sku, int $qty, array $expected): void
+    {
+        if ($qty < 2) {
+            $this->markTestSkipped('Needs an order quantity that can be halved.');
+        }
+
+        $order = $this->placeOrderFor($sku, $qty);
+        $this->payInvoice($order);
+
+        $soap = $this->soapClient();
+        $soap->resetCalls();
+
+        $this->refundHalfOf($order);
+
+        $returned = $this->productLines($soap->firstCallArgs('Returned')['cartItems'] ?? []);
+
+        $halved = array_map(
+            static fn ($line) => [$line[0], $line[1] / 2, $line[2]],
+            $expected
+        );
+
+        $this->assertSame(
+            $halved,
+            $returned,
+            "A half refund of $sku returns the wrong quantities. Each line should come back at "
+            . 'half the units the order reported.'
+        );
+    }
+
+    /**
+     * Place an order holding one seeded product.
+     */
+    private function placeOrderFor(string $sku, int $qty): Order
+    {
+        $product = $this->seededProduct($sku);
+
+        $quote = $this->newGuestQuote();
+        $quote->addProduct($product, new DataObject($this->buyRequestFor($product, $qty)));
+        $this->collectAndSaveQuote($quote);
+
+        $orderId = $this->get(CartManagementInterface::class)->placeOrder((int) $quote->getId());
+
+        return $this->get(OrderRepositoryInterface::class)->get($orderId);
+    }
+
+    /**
+     * Credit memo for half of every refundable line.
+     *
+     * "Refundable" means not dummy, which is the same test the admin credit memo
+     * form applies when deciding which rows get a quantity box — and it moves
+     * between parent and child depending on the composite. A dynamic bundle's
+     * priced lines are its selections, so listing the wrapper instead makes
+     * CreditmemoFactory::getQtyToRefund() return 0 for every selection and the
+     * refund comes back empty.
+     */
+    private function refundHalfOf(Order $order): void
+    {
+        $qtys = [];
+        foreach ($order->getAllItems() as $item) {
+            if ($item->isDummy()) {
+                continue;
+            }
+            $qtys[(int) $item->getId()] = (float) $item->getQtyOrdered() / 2;
+        }
+
+        $creditmemo = $this->get(CreditmemoFactory::class)->createByOrder($order, ['qtys' => $qtys]);
+        $this->get(CreditmemoService::class)->refund($creditmemo, true);
+    }
+}

--- a/Test/Integration/Model/Tax/CatalogTypeLookupTest.php
+++ b/Test/Integration/Model/Tax/CatalogTypeLookupTest.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * Taxcloud_Magento2
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ */
+
+namespace Taxcloud\Magento2\Test\Integration\Model\Tax;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\DataObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Magento\Quote\Model\Quote;
+use Taxcloud\Magento2\Test\Integration\IntegrationTestCase;
+use Taxcloud\Magento2\Test\Integration\SeededCatalogTrait;
+
+/**
+ * What TaxCloud is told about a cart, once per catalog type, against quote-item
+ * trees that Magento built rather than a test wrote.
+ *
+ * The unit table in Test/Unit/Model/Gateway/CartLineShapesTest asserts the same
+ * expectations against mocks. Mocks are the reason the bundle regression shipped:
+ * they agree with whatever shape the test author believed in, and the author
+ * believed a bundle child's qty was absolute. Only a real quote disagrees. So
+ * these two files are deliberately redundant — the unit one is fast and total,
+ * this one is slow and true.
+ *
+ * The oracle is a flat rate applied by the SOAP double, NOT TaxCloud. Real rates
+ * change, and per-line cent rounding makes them a poor thing to assert (the same
+ * 8.25% surfaces as "8.3%" on a $10 line and "8.267%" on a $30 one). What is
+ * asserted here is what we ask for and what we do with the answer.
+ */
+class CatalogTypeLookupTest extends IntegrationTestCase
+{
+    use SeededCatalogTrait;
+
+    /** Flat rate the SOAP double applies to every line it is sent. */
+    private const RATE = 0.10;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->installSoapMock($this->soapResponsesWith([
+            'lookup' => $this->flatRateLookupResponder(self::RATE),
+        ]));
+    }
+
+    /**
+     * The cart lines each catalog type must produce.
+     *
+     * Expectations mirror what scripts/verify-test-products.php prints for the
+     * same seeded product, which is in turn what Magento actually builds.
+     *
+     * @return array<string, array{sku: string, qty: int, expected: array<int, array{0: string, 1: float, 2: float}>}>
+     */
+    public static function catalogTypeProvider(): array
+    {
+        return [
+            'simple' => [
+                'sku' => 'test-product',
+                'qty' => 1,
+                'expected' => [['test-product', 1.0, 10.0]],
+            ],
+            'virtual' => [
+                'sku' => 'test-virtual',
+                'qty' => 1,
+                'expected' => [['test-virtual', 1.0, 10.0]],
+            ],
+            'downloadable' => [
+                'sku' => 'test-downloadable',
+                'qty' => 1,
+                'expected' => [['test-downloadable', 1.0, 10.0]],
+            ],
+            'configurable' => [
+                'sku' => 'test-configurable',
+                'qty' => 1,
+                'expected' => [['test-variant-red', 1.0, 10.0]],
+            ],
+            // Explodes into independent lines; no grouped line of its own.
+            'grouped' => [
+                'sku' => 'test-grouped',
+                'qty' => 1,
+                'expected' => [['test-product', 1.0, 10.0], ['test-virtual', 1.0, 10.0]],
+            ],
+            // The regression, at qty 3: the selections store 1 and 2 per bundle,
+            // so TaxCloud has to be told 3 and 6. Told 1 and 2, the shopper is
+            // charged a third of what they owe.
+            'bundle dynamic' => [
+                'sku' => 'test-bundle-dynamic',
+                'qty' => 3,
+                'expected' => [['test-product', 3.0, 10.0], ['test-virtual', 6.0, 10.0]],
+            ],
+            // Parent-priced: one line, and the selections must not appear.
+            'bundle fixed' => [
+                'sku' => 'test-bundle-fixed',
+                'qty' => 1,
+                'expected' => [['test-bundle-fixed', 1.0, 50.0]],
+            ],
+            'giftcard' => [
+                'sku' => 'test-giftcard',
+                'qty' => 1,
+                'expected' => [['test-giftcard', 1.0, 25.0]],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider catalogTypeProvider
+     */
+    #[DataProvider('catalogTypeProvider')]
+    public function testLookupCartLinesForCatalogType(string $sku, int $qty, array $expected): void
+    {
+        $quote = $this->quoteWith($sku, $qty);
+        $soap = $this->soapClient();
+
+        $this->assertGreaterThanOrEqual(
+            1,
+            $soap->callCount('lookup'),
+            "Collecting totals for $sku should have triggered a lookup."
+        );
+
+        $this->assertSame(
+            $expected,
+            $this->productLines($soap->firstCallArgs('lookup')['cartItems'] ?? []),
+            "The lookup payload for $sku does not describe the cart Magento built. Compare with "
+            . 'scripts/verify-test-products.php, which prints the same tree.'
+        );
+    }
+
+    /**
+     * The invariant that generalises past this table: whatever the type, the
+     * basis we report has to be the basis Magento taxes. Under-report it and the
+     * shopper is undercharged; over-report it and TaxCloud is told the store sold
+     * more than it did. The original bundle defect did both at once.
+     *
+     * @dataProvider catalogTypeProvider
+     */
+    #[DataProvider('catalogTypeProvider')]
+    public function testReportedBasisMatchesTheQuoteSubtotal(string $sku, int $qty, array $expected): void
+    {
+        $quote = $this->quoteWith($sku, $qty);
+
+        $basis = 0.0;
+        foreach ($this->productLines($this->soapClient()->firstCallArgs('lookup')['cartItems'] ?? []) as $line) {
+            $basis += $line[1] * $line[2];
+        }
+
+        $this->assertEqualsWithDelta(
+            (float) $this->taxedAddress($quote)->getSubtotal(),
+            $basis,
+            0.01,
+            "The taxable basis sent to TaxCloud for $sku differs from the quote subtotal."
+        );
+    }
+
+    /**
+     * And the answer has to land: every line we sent gets its tax written back
+     * onto the quote item that produced it, at the rate the double applied.
+     *
+     * @dataProvider catalogTypeProvider
+     */
+    #[DataProvider('catalogTypeProvider')]
+    public function testLookupTaxIsAppliedToTheQuote(string $sku, int $qty, array $expected): void
+    {
+        $quote = $this->quoteWith($sku, $qty);
+
+        $expectedTax = 0.0;
+        foreach ($expected as [, $lineQty, $linePrice]) {
+            $expectedTax += round($lineQty * $linePrice * self::RATE, 2);
+        }
+
+        $address = $this->taxedAddress($quote);
+
+        $this->assertEqualsWithDelta(
+            $expectedTax,
+            (float) $address->getTaxAmount() - (float) $address->getShippingTaxAmount(),
+            0.02,
+            "Product tax on the $sku quote does not match the tax TaxCloud returned for its lines."
+        );
+    }
+
+    /**
+     * Virtual, downloadable and virtual gift cards ship nothing, so Magento
+     * assigns a cart made only of them to the BILLING address and collects
+     * totals there (Quote\Address::getAllItems). The tax therefore sources to
+     * where the buyer is billed, and the shipping address stays empty — the
+     * reason the two assertions above have to ask which address holds the items
+     * rather than assuming it is the shipping one.
+     *
+     * Add one shippable line and the whole cart moves to the shipping address,
+     * virtual items included. That is Magento's rule, not ours, and it is worth
+     * pinning: it decides which state's rate a digital sale is taxed at.
+     */
+    public function testVirtualOnlyCartIsTaxedAgainstTheBillingAddress(): void
+    {
+        $quote = $this->quoteWith('test-virtual', 1);
+
+        $this->assertTrue($quote->isVirtual(), 'A cart of one virtual product should be a virtual quote.');
+        $this->assertEqualsWithDelta(
+            0.0,
+            (float) $quote->getShippingAddress()->getSubtotal(),
+            0.01,
+            'A virtual quote should leave the shipping address empty.'
+        );
+        $this->assertGreaterThan(
+            0.0,
+            (float) $quote->getBillingAddress()->getTaxAmount(),
+            'A virtual quote should carry its tax on the billing address.'
+        );
+    }
+
+    /**
+     * The same virtual product in a cart that also ships something is taxed
+     * against the shipping address instead — all items follow the shippable one.
+     */
+    public function testVirtualLineInAShippableCartFollowsTheShippingAddress(): void
+    {
+        $repository = $this->get(ProductRepositoryInterface::class);
+
+        $quote = $this->newGuestQuote();
+        $quote->addProduct($repository->get('test-virtual'), new DataObject(['qty' => 1]));
+        $quote->addProduct($repository->get('test-product'), new DataObject(['qty' => 1]));
+        $this->collectAndSaveQuote($quote);
+
+        $this->assertFalse($quote->isVirtual(), 'A cart with a shippable line is not a virtual quote.');
+        $this->assertSame(
+            [['test-virtual', 1.0, 10.0], ['test-product', 1.0, 10.0]],
+            $this->productLines($this->soapClient()->firstCallArgs('lookup')['cartItems'] ?? []),
+            'Both lines should reach TaxCloud, sourced to the shipping address.'
+        );
+        $this->assertGreaterThan(
+            0.0,
+            (float) $quote->getShippingAddress()->getTaxAmount(),
+            'A mixed cart carries its tax on the shipping address.'
+        );
+    }
+
+    /**
+     * Whichever address Magento put the items on.
+     */
+    private function taxedAddress(Quote $quote)
+    {
+        return $quote->isVirtual() ? $quote->getBillingAddress() : $quote->getShippingAddress();
+    }
+
+    /**
+     * Build, collect and return a guest quote holding one seeded product.
+     */
+    private function quoteWith(string $sku, int $qty): Quote
+    {
+        $product = $this->seededProduct($sku);
+
+        $quote = $this->newGuestQuote();
+        $quote->addProduct($product, new DataObject($this->buyRequestFor($product, $qty)));
+
+        return $this->collectAndSaveQuote($quote);
+    }
+
+
+
+}

--- a/Test/Integration/Model/Tax/TaxInvariantsTest.php
+++ b/Test/Integration/Model/Tax/TaxInvariantsTest.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Taxcloud_Magento2
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ */
+
+namespace Taxcloud\Magento2\Test\Integration\Model\Tax;
+
+use Magento\Framework\DataObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Magento\Quote\Api\CartManagementInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+use Taxcloud\Magento2\Test\Integration\IntegrationTestCase;
+use Taxcloud\Magento2\Test\Integration\SeededCatalogTrait;
+
+/**
+ * Properties that must hold for every catalog type, at every stage of an order's
+ * life, whatever the rate.
+ *
+ * These are the tests worth having. A per-type expectation only catches the
+ * types someone thought to list; an invariant catches the type nobody has added
+ * yet. Both defects found in the bundle work break an invariant here:
+ *
+ *  - the shopper was charged tax on a third of the goods (sum invariant)
+ *  - TaxCloud was told the store sold $70 of goods out of a $50 cart, and the
+ *    captured transaction kept that number (lifecycle invariant)
+ *
+ * Neither needed a rate to detect.
+ */
+class TaxInvariantsTest extends IntegrationTestCase
+{
+    use SeededCatalogTrait;
+
+    private const RATE = 0.10;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->installSoapMock($this->soapResponsesWith([
+            'lookup' => $this->flatRateLookupResponder(self::RATE),
+        ]));
+    }
+
+    /**
+     * The shapes that differ structurally. Simple, virtual, downloadable and
+     * gift card all behave as "one line, one product" and are covered per-type
+     * in CatalogTypeLookupTest; repeating them through a full order lifecycle
+     * would buy coverage of Magento, not of this module.
+     *
+     * @return array<string, array{sku: string, qty: int}>
+     */
+    public static function structuralShapeProvider(): array
+    {
+        return [
+            'bundle dynamic (children carry the basis)' => ['sku' => 'test-bundle-dynamic', 'qty' => 3],
+            'bundle fixed (parent carries the basis)'   => ['sku' => 'test-bundle-fixed', 'qty' => 2],
+            'configurable (parent carries the basis)'   => ['sku' => 'test-configurable', 'qty' => 2],
+            'grouped (independent lines)'               => ['sku' => 'test-grouped', 'qty' => 1],
+            'simple (the control)'                      => ['sku' => 'test-product', 'qty' => 2],
+        ];
+    }
+
+    /**
+     * A refund has to describe the same goods the order authorized.
+     *
+     * The two sides read different tables — a quote child stores its quantity per
+     * parent, an order child stores it absolutely — so it is entirely possible
+     * for both to look locally correct and still disagree. When they do, TaxCloud
+     * is asked to reverse something the store never reported selling.
+     *
+     * @dataProvider structuralShapeProvider
+     */
+    #[DataProvider('structuralShapeProvider')]
+    public function testReturnDescribesTheSameGoodsAsTheLookup(string $sku, int $qty): void
+    {
+        $order = $this->placeOrderFor($sku, $qty);
+        $soap = $this->soapClient();
+
+        $lookupLines = $this->productLines($soap->firstCallArgs('lookup')['cartItems'] ?? []);
+
+        // Nothing is refundable until it is paid for.
+        $this->payInvoice($order);
+        $soap->resetCalls();
+
+        $this->refundOrder($order);
+
+        $this->assertSame(
+            1,
+            $soap->callCount('Returned'),
+            'Refunding should call Returned exactly once.'
+        );
+
+        $returnLines = $this->productLines($soap->firstCallArgs('Returned')['cartItems'] ?? []);
+
+        $this->assertSame(
+            $this->sortLines($lookupLines),
+            $this->sortLines($returnLines),
+            "The full refund of $sku returns different goods than the order looked up. "
+            . 'One side is reading a composite line the other is not.'
+        );
+    }
+
+    /**
+     * The order's tax total has to be the tax on its lines.
+     *
+     * A children-priced bundle displays its wrapper's tax as the sum of its
+     * children's, so counting the wrapper as well double-counts it — which is
+     * exactly why Magento leaves it out of the address total, and why this sum
+     * has to skip it too.
+     *
+     * @dataProvider structuralShapeProvider
+     */
+    #[DataProvider('structuralShapeProvider')]
+    public function testOrderTaxEqualsItsLineTaxPlusShipping(string $sku, int $qty): void
+    {
+        $order = $this->placeOrderFor($sku, $qty);
+
+        $lineTax = 0.0;
+        foreach ($order->getAllItems() as $item) {
+            // A wrapper's tax is an echo of its children's, not tax of its own.
+            if (!$item->getParentItemId() && $item->isChildrenCalculated()) {
+                continue;
+            }
+            $lineTax += (float) $item->getTaxAmount();
+        }
+
+        $this->assertEqualsWithDelta(
+            (float) $order->getTaxAmount(),
+            $lineTax + (float) $order->getShippingTaxAmount(),
+            0.02,
+            "Order $sku reports a tax total its own line items do not add up to. "
+            . 'Either a line is taxed and not counted, or counted twice.'
+        );
+    }
+
+    /**
+     * Nothing may be reported to TaxCloud that the shopper was not charged for.
+     *
+     * The basis is checked against the quote in CatalogTypeLookupTest; here it is
+     * checked against the placed order, after conversion — the point at which the
+     * captured transaction becomes what gets filed.
+     *
+     * @dataProvider structuralShapeProvider
+     */
+    #[DataProvider('structuralShapeProvider')]
+    public function testReportedBasisMatchesTheOrderSubtotal(string $sku, int $qty): void
+    {
+        $order = $this->placeOrderFor($sku, $qty);
+
+        $basis = 0.0;
+        foreach ($this->productLines($this->soapClient()->firstCallArgs('lookup')['cartItems'] ?? []) as $line) {
+            $basis += $line[1] * $line[2];
+        }
+
+        $this->assertEqualsWithDelta(
+            (float) $order->getSubtotal(),
+            $basis,
+            0.01,
+            "The goods reported to TaxCloud for $sku are worth more or less than the order is."
+        );
+    }
+
+    /**
+     * Changing the quantity has to change what is reported.
+     *
+     * The collector snapshots pre-tax values to stop incl-tax compounding across
+     * repeated collections, and that snapshot is keyed on quantity. Key it on the
+     * wrong quantity — a bundle child's per-parent one, say — and a cart edit
+     * either fails to invalidate or invalidates constantly.
+     */
+    public function testChangingBundleQuantityRestatesTheReportedGoods(): void
+    {
+        $product = $this->seededProduct('test-bundle-dynamic');
+
+        $quote = $this->newGuestQuote();
+        $quote->addProduct($product, new DataObject($this->buyRequestFor($product, 1)));
+        $this->collectAndSaveQuote($quote);
+
+        $this->assertSame(
+            [['test-product', 1.0, 10.0], ['test-virtual', 2.0, 10.0]],
+            $this->productLines($this->soapClient()->firstCallArgs('lookup')['cartItems'] ?? []),
+            'One bundle should report one and two units of its selections.'
+        );
+
+        // Same cart, quantity raised the way a shopper raises it. The collected
+        // flag has to be cleared by hand: Quote::collectTotals() returns early
+        // while it is set, so without this the "after" assertion would just be
+        // re-reading the "before" state.
+        foreach ($quote->getAllItems() as $item) {
+            if (!$item->getParentItem()) {
+                $item->setQty(3);
+            }
+        }
+        $this->soapClient()->resetCalls();
+        $quote->setTotalsCollectedFlag(false);
+        $this->collectAndSaveQuote($quote);
+
+        $this->assertSame(
+            [['test-product', 3.0, 10.0], ['test-virtual', 6.0, 10.0]],
+            $this->productLines($this->soapClient()->firstCallArgs('lookup')['cartItems'] ?? []),
+            'Raising a bundle to qty 3 should triple the units reported, not leave them stale.'
+        );
+    }
+
+    /**
+     * Place an order holding one seeded product.
+     */
+    private function placeOrderFor(string $sku, int $qty): Order
+    {
+        $product = $this->seededProduct($sku);
+
+        $quote = $this->newGuestQuote();
+        $quote->addProduct($product, new DataObject($this->buyRequestFor($product, $qty)));
+        $this->collectAndSaveQuote($quote);
+
+        $orderId = $this->get(CartManagementInterface::class)->placeOrder((int) $quote->getId());
+
+        return $this->get(OrderRepositoryInterface::class)->get($orderId);
+    }
+
+    /**
+     * Order-independent comparison: the two payloads are built by different code
+     * walking different tables, so line order is not part of the contract.
+     */
+    private function sortLines(array $lines): array
+    {
+        usort($lines, static fn ($a, $b) => [$a[0], $a[1]] <=> [$b[0], $b[1]]);
+
+        return $lines;
+    }
+}

--- a/Test/Integration/SeededCatalogTrait.php
+++ b/Test/Integration/SeededCatalogTrait.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Taxcloud_Magento2
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ */
+
+namespace Taxcloud\Magento2\Test\Integration;
+
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Module\Manager as ModuleManager;
+
+/**
+ * Adding a seeded product of any catalog type to a cart, and reading back the
+ * lines that reached TaxCloud.
+ *
+ * Every composite type needs its own buy request, and getting one wrong fails in
+ * ways that look like tax bugs ("Product that you are trying to add is not
+ * available", "Please specify product option(s)"). Keeping that knowledge in one
+ * place means a test that exercises a type is not also a test of whether its
+ * author knew how to add it.
+ *
+ * The same option-choosing logic lives in scripts/verify-test-products.php,
+ * which runs at install time — if these requests ever stop working, that script
+ * fails first and names the product.
+ */
+trait SeededCatalogTrait
+{
+    /**
+     * The buy request a seeded product needs, choosing every available option so
+     * the add is deterministic.
+     *
+     * @param \Magento\Catalog\Api\Data\ProductInterface $product
+     * @return array<string, mixed>
+     */
+    protected function buyRequestFor($product, int $qty = 1): array
+    {
+        $request = ['qty' => $qty];
+        $type = $product->getTypeInstance();
+
+        switch ($product->getTypeId()) {
+            case 'configurable':
+                $superAttribute = [];
+                foreach ($type->getConfigurableAttributesAsArray($product) as $attribute) {
+                    $superAttribute[$attribute['attribute_id']] = $attribute['values'][0]['value_index'];
+                }
+                $request['super_attribute'] = $superAttribute;
+                break;
+
+            case 'grouped':
+                // A grouped product has no quantity of its own — the shopper sets
+                // one per association — so $qty is applied to each of them. That
+                // also means the resulting lines are independent and can be
+                // refunded separately, unlike a composite's.
+                $superGroup = [];
+                foreach ($type->getAssociatedProducts($product) as $associated) {
+                    $superGroup[$associated->getId()] = $qty;
+                }
+                $request['super_group'] = $superGroup;
+                break;
+
+            case 'bundle':
+                $options = $type->getOptionsCollection($product);
+                $selections = $type->getSelectionsCollection($options->getAllIds(), $product);
+                $bundleOption = [];
+                foreach ($options as $option) {
+                    foreach ($selections as $selection) {
+                        if ((int) $selection->getOptionId() === (int) $option->getId()) {
+                            $bundleOption[(int) $option->getId()][] = (int) $selection->getSelectionId();
+                        }
+                    }
+                }
+                $request['bundle_option'] = $bundleOption;
+                break;
+
+            case 'giftcard':
+                $amounts = $product->getGiftcardAmounts();
+                $request['giftcard_amount'] = $amounts[0]['value'] ?? $amounts[0]['website_value'] ?? 25.00;
+                $request['giftcard_sender_name'] = 'Test Sender';
+                $request['giftcard_sender_email'] = 'sender@example.com';
+                $request['giftcard_recipient_name'] = 'Test Recipient';
+                $request['giftcard_recipient_email'] = 'recipient@example.com';
+                break;
+        }
+
+        return $request;
+    }
+
+    /**
+     * Load a seeded product, skipping the test when its module is not installed
+     * and failing it when the seed simply has not been run.
+     *
+     * @return \Magento\Catalog\Api\Data\ProductInterface
+     */
+    protected function seededProduct(string $sku)
+    {
+        if ($sku === 'test-giftcard' && !$this->get(ModuleManager::class)->isEnabled('Magento_GiftCard')) {
+            $this->markTestSkipped('Magento_GiftCard is Adobe Commerce only.');
+        }
+
+        try {
+            return $this->get(ProductRepositoryInterface::class)->get($sku);
+        } catch (NoSuchEntityException $e) {
+            $this->fail("Seed data missing: $sku (run scripts/seed-test-data.php).");
+        }
+    }
+
+    /**
+     * TaxCloud cart lines as [sku, qty, price], with shipping dropped.
+     *
+     * @param array<int, array<string, mixed>> $cartItems
+     * @return array<int, array{0: string, 1: float, 2: float}>
+     */
+    protected function productLines(array $cartItems): array
+    {
+        return array_map(
+            static fn ($line) => [
+                (string) $line['ItemID'],
+                (float) $line['Qty'],
+                round((float) $line['Price'], 4),
+            ],
+            array_values(array_filter(
+                $cartItems,
+                static fn ($line) => ($line['ItemID'] ?? null) !== 'shipping'
+            ))
+        );
+    }
+
+    /**
+     * A lookup double that taxes whatever it is handed at a flat rate.
+     *
+     * Asserting against real TaxCloud rates would make these tests a subscription
+     * to someone else's rate table; per-line cent rounding makes it worse (one
+     * 8.25% rate reads as 8.3% on a $10 line and 8.267% on a $30 one). A flat
+     * rate keeps the assertions about our arithmetic.
+     */
+    protected function flatRateLookupResponder(float $rate): \Closure
+    {
+        return static function (array $args) use ($rate): array {
+            $responses = [];
+            foreach ($args['cartItems'] ?? [] as $line) {
+                $responses[] = [
+                    'CartItemIndex' => $line['Index'],
+                    'TaxAmount' => round($line['Price'] * $line['Qty'] * $rate, 2),
+                ];
+            }
+
+            return [
+                'LookupResult' => [
+                    'ResponseType' => 'OK',
+                    'Messages' => '',
+                    'CartItemsResponse' => ['CartItemResponse' => $responses],
+                ],
+            ];
+        };
+    }
+}

--- a/Test/Unit/Model/CompositeItemResolverTest.php
+++ b/Test/Unit/Model/CompositeItemResolverTest.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Taxcloud_Magento2
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ */
+
+namespace Taxcloud\Magento2\Test\Unit\Model;
+
+use Magento\Sales\Model\Order\Item as OrderItem;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use Taxcloud\Magento2\Model\CompositeItemResolver;
+use Taxcloud\Magento2\Test\Unit\Double as Dbl;
+
+/**
+ * Covers the composite-product rule shared by the Lookup, return and cancel
+ * payloads: which line carries the taxable basis, and on which scale its
+ * quantity is stored.
+ *
+ * The scenario throughout is the one that surfaced the bug — a qty-2
+ * dynamic-price bundle holding one $10 selection, where the quote stores the
+ * child at qty 1 with a row total of $20.
+ */
+#[AllowMockObjectsWithoutExpectations]
+class CompositeItemResolverTest extends TestCase
+{
+    /**
+     * A quote item stubbed with only the hierarchy accessors the resolver reads.
+     */
+    private function quoteItem($qty, $parent = null, array $children = [], $childrenCalculated = false)
+    {
+        $item = $this->getMockBuilder(Dbl\QuoteItemDouble::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getQty', 'getParentItem', 'getChildren', 'isChildrenCalculated'])
+            ->getMock();
+        $item->method('getQty')->willReturn($qty);
+        $item->method('getParentItem')->willReturn($parent);
+        $item->method('getChildren')->willReturn($children);
+        $item->method('isChildrenCalculated')->willReturn($childrenCalculated);
+
+        return $item;
+    }
+
+    private function orderItem($parentItemId, $childrenCalculated, array $children = [])
+    {
+        $item = $this->createMock(OrderItem::class);
+        $item->method('getParentItemId')->willReturn($parentItemId);
+        $item->method('isChildrenCalculated')->willReturn($childrenCalculated);
+        $item->method('getChildrenItems')->willReturn($children);
+
+        return $item;
+    }
+
+    public function testDynamicBundleParentIsPricedByChildren()
+    {
+        $parent = $this->quoteItem(2.0, null, [$this->quoteItem(1.0)], true);
+
+        $this->assertTrue(CompositeItemResolver::isQuoteParentPricedByChildren($parent));
+    }
+
+    public function testConfigurableParentIsNotPricedByChildren()
+    {
+        // A configurable's children exist but are priced at 0 — the parent line
+        // carries the basis, and Magento never maps the children into the tax
+        // details at all.
+        $parent = $this->quoteItem(2.0, null, [$this->quoteItem(1.0)], false);
+
+        $this->assertFalse(CompositeItemResolver::isQuoteParentPricedByChildren($parent));
+    }
+
+    /**
+     * Grouped, virtual, downloadable and gift card lines all reach the cart as
+     * childless top-level items, so this is the shape that has to stay a cart
+     * line of its own.
+     */
+    public function testChildlessItemIsNotPricedByChildren()
+    {
+        $this->assertFalse(CompositeItemResolver::isQuoteParentPricedByChildren($this->quoteItem(1.0)));
+    }
+
+    /**
+     * The children test comes first for a reason: a childless line is never
+     * suppressed, whatever it claims about child calculation. Only a bundle
+     * carries the price type behind that claim today, but a bundle whose
+     * children failed to load would otherwise be dropped from the request and
+     * silently untaxed — its own price is the sum of those children, so sending
+     * it reports the same basis.
+     */
+    public function testChildlessItemSurvivesEvenWhenItClaimsChildCalculation()
+    {
+        $item = $this->quoteItem(2.0, null, [], true);
+
+        $this->assertFalse(CompositeItemResolver::isQuoteParentPricedByChildren($item));
+    }
+
+    public function testChildIsNeverItsOwnPricedByChildrenParent()
+    {
+        $parent = $this->quoteItem(2.0, null, [], true);
+        $child = $this->quoteItem(1.0, $parent, [], true);
+
+        $this->assertFalse(CompositeItemResolver::isQuoteParentPricedByChildren($child));
+    }
+
+    public function testQuoteQtyMultipliesChildByParentQty()
+    {
+        $parent = $this->quoteItem(2.0);
+        $child = $this->quoteItem(1.0, $parent);
+
+        // The regression itself: 1 stored on the child, 2 units actually sold.
+        $this->assertSame(2.0, CompositeItemResolver::quoteQty($child));
+    }
+
+    public function testQuoteQtyMultipliesMultiUnitSelections()
+    {
+        $parent = $this->quoteItem(3.0);
+        $child = $this->quoteItem(2.0, $parent);
+
+        $this->assertSame(6.0, CompositeItemResolver::quoteQty($child));
+    }
+
+    /**
+     * A grouped product explodes into one independent line per associated
+     * product, each with its own absolute qty — nothing to multiply.
+     */
+    public function testQuoteQtyLeavesTopLevelItemAlone()
+    {
+        $this->assertSame(2.0, CompositeItemResolver::quoteQty($this->quoteItem(2.0)));
+    }
+
+    public function testQuoteQtyCoercesStringQuantities()
+    {
+        // Quote item qty arrives as a decimal string off the DB row.
+        $parent = $this->quoteItem('2.0000');
+        $child = $this->quoteItem('1.0000', $parent);
+
+        $this->assertSame(2.0, CompositeItemResolver::quoteQty($child));
+    }
+
+    public function testOrderDynamicBundleParentIsPricedByChildren()
+    {
+        $this->assertTrue(CompositeItemResolver::isOrderParentPricedByChildren($this->orderItem(null, true)));
+    }
+
+    public function testOrderChildIsNotAPricedByChildrenParent()
+    {
+        // A bundle child answers isChildrenCalculated() from its parent's
+        // options, so the parent-id check is what keeps it out.
+        $this->assertFalse(CompositeItemResolver::isOrderParentPricedByChildren($this->orderItem(54, true)));
+    }
+
+    public function testOrderConfigurableParentIsNotPricedByChildren()
+    {
+        $this->assertFalse(CompositeItemResolver::isOrderParentPricedByChildren($this->orderItem(null, false)));
+    }
+
+    public function testOrderBasisItemsExpandsDynamicBundleToChildren()
+    {
+        $childA = $this->orderItem(54, true);
+        $childB = $this->orderItem(54, true);
+        $parent = $this->orderItem(null, true, [7 => $childA, 8 => $childB]);
+
+        // Keyed by item id in Magento; the caller indexes positionally.
+        $this->assertSame([$childA, $childB], CompositeItemResolver::orderBasisItems($parent));
+    }
+
+    public function testOrderBasisItemsLeavesOrdinaryItemAlone()
+    {
+        $item = $this->orderItem(null, false);
+
+        $this->assertSame([$item], CompositeItemResolver::orderBasisItems($item));
+    }
+
+    public function testOrderBasisItemsFallsBackToParentWhenChildrenAreNotLinked()
+    {
+        // Over-reporting a line is recoverable; dropping it silently is not.
+        $parent = $this->orderItem(null, true, []);
+
+        $this->assertSame([$parent], CompositeItemResolver::orderBasisItems($parent));
+    }
+}

--- a/Test/Unit/Model/Fallback/MagentoTaxFallbackTest.php
+++ b/Test/Unit/Model/Fallback/MagentoTaxFallbackTest.php
@@ -171,6 +171,102 @@ class MagentoTaxFallbackTest extends TestCase
         $this->assertArrayNotHasKey('orphan', $result['product']);
     }
 
+    /**
+     * The fallback builds a flat detail list with no parent codes, so Magento's
+     * own TaxCalculation cannot apply its parent-quantity rule for us: a bundle
+     * child has to arrive already parent-multiplied, and the wrapper — whose
+     * price is just the sum of those children — must not arrive at all.
+     */
+    public function testDynamicBundleIsPricedByItsChildrenAtTheParentMultipliedQty()
+    {
+        $this->customerAddressFactory->method('create')->willReturn($this->createMock(AddressInterface::class));
+        $this->quoteDetailsFactory->method('create')->willReturn($this->createMock(QuoteDetailsInterface::class));
+        $this->taxClassKeyFactory->method('create')
+            ->willReturnCallback(fn () => $this->createMock(TaxClassKeyInterface::class));
+
+        $mapped = [];
+        $this->quoteDetailsItemFactory->method('create')->willReturnCallback(
+            function () use (&$mapped) {
+                $detail = $this->createMock(QuoteDetailsItemInterface::class);
+                $at = count($mapped);
+                $mapped[$at] = ['code' => null, 'qty' => null];
+                $detail->method('setCode')->willReturnCallback(function ($code) use (&$mapped, $at) {
+                    $mapped[$at]['code'] = $code;
+                });
+                $detail->method('setQuantity')->willReturnCallback(function ($qty) use (&$mapped, $at) {
+                    $mapped[$at]['qty'] = $qty;
+                });
+
+                return $detail;
+            }
+        );
+
+        [$parent, $child] = $this->dynamicBundleQuoteItems();
+
+        $itemsByType = [
+            'product' => [
+                'bundle-1' => ['item' => 'ignored'],
+                'child-1' => ['item' => 'ignored'],
+            ],
+        ];
+
+        $taxDetails = $this->createMock(TaxDetailsInterface::class);
+        $taxDetails->method('getItems')->willReturn([]);
+        $this->taxCalculationService->method('calculateTax')->willReturn($taxDetails);
+
+        $assignment = $this->shippingAssignmentWithAddress($this->quoteAddress(), [$parent, $child]);
+        $quote = $this->createMock(Quote::class);
+        $quote->method('getStoreId')->willReturn(1);
+
+        $this->fallback()->calculate($itemsByType, $assignment, $quote);
+
+        $this->assertSame([['code' => 'child-1', 'qty' => 2.0]], $mapped);
+    }
+
+    /**
+     * A qty-2 dynamic bundle holding one $10 selection, as the quote stores it.
+     * Returns [parent, child].
+     */
+    private function dynamicBundleQuoteItems()
+    {
+        $product = $this->getMockBuilder(ProductDouble::class)
+            ->disableOriginalConstructor()->onlyMethods(['getTaxClassId'])->getMock();
+        $product->method('getTaxClassId')->willReturn('2');
+
+        $build = function ($code, $qty, $parent, $children, $childrenCalculated) use ($product) {
+            $item = $this->getMockBuilder(QuoteItemDouble::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods([
+                    'getTaxCalculationItemId', 'getProduct', 'getPrice', 'getQty', 'getDiscountAmount',
+                    'getParentItem', 'getChildren', 'isChildrenCalculated',
+                ])
+                ->getMock();
+            $item->method('getTaxCalculationItemId')->willReturn($code);
+            $item->method('getProduct')->willReturn($product);
+            $item->method('getPrice')->willReturn(10.0);
+            $item->method('getQty')->willReturn($qty);
+            $item->method('getDiscountAmount')->willReturn(0);
+            $item->method('getParentItem')->willReturn($parent);
+            $item->method('isChildrenCalculated')->willReturn($childrenCalculated);
+            if (is_callable($children)) {
+                $item->method('getChildren')->willReturnCallback($children);
+            } else {
+                $item->method('getChildren')->willReturn($children);
+            }
+
+            return $item;
+        };
+
+        $children = [];
+        $parent = $build('bundle-1', 2, null, function () use (&$children) {
+            return $children;
+        }, true);
+        $child = $build('child-1', 1, $parent, [], false);
+        $children[] = $child;
+
+        return [$parent, $child];
+    }
+
     public function testMapsMagentoTaxDetailsToProductAndShippingResult()
     {
         $this->customerAddressFactory->method('create')->willReturn($this->createMock(AddressInterface::class));

--- a/Test/Unit/Model/Gateway/CartLineShapesTest.php
+++ b/Test/Unit/Model/Gateway/CartLineShapesTest.php
@@ -1,0 +1,407 @@
+<?php
+/**
+ * Taxcloud_Magento2
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ */
+
+namespace Taxcloud\Magento2\Test\Unit\Model\Gateway;
+
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Creditmemo;
+use Magento\Sales\Model\Order\Creditmemo\Item as CreditmemoItem;
+use Magento\Sales\Model\Order\Item as OrderItem;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Taxcloud\Magento2\Model\Config\TaxcloudConfig;
+use Taxcloud\Magento2\Model\Gateway\RequestBuilder;
+use Taxcloud\Magento2\Model\ProductTicService;
+use Taxcloud\Magento2\Model\RefundDistributor;
+use Taxcloud\Magento2\Test\Unit\Double as Dbl;
+
+/**
+ * One table, one row per catalog type: given the quote-item tree Magento builds
+ * for that type, these are the cart lines TaxCloud must be told about.
+ *
+ * The shapes are not invented. Each row mirrors what scripts/verify-test-
+ * products.php printed when it added the seeded product to a real quote, so a
+ * row failing here means either the module changed or Magento did — and the
+ * verify script is the tie-breaker.
+ *
+ * What varies between types is only ever two things: which line carries the
+ * price, and what quantity that line stores. Everything else about tax is the
+ * same, which is why this file is a table and not eight test classes.
+ */
+#[AllowMockObjectsWithoutExpectations]
+class CartLineShapesTest extends TestCase
+{
+    private $productTicService;
+    private RequestBuilder $builder;
+
+    protected function setUp(): void
+    {
+        $config = $this->createMock(TaxcloudConfig::class);
+        $this->productTicService = $this->createMock(ProductTicService::class);
+        $this->productTicService->method('getProductTic')->willReturn('20000');
+        $this->productTicService->method('getShippingTic')->willReturn('11010');
+
+        $this->builder = new RequestBuilder(
+            $config,
+            $this->createMock(\Magento\Framework\App\Config\ScopeConfigInterface::class),
+            $this->createMock(\Magento\Directory\Model\RegionFactory::class),
+            $this->productTicService,
+            $this->createMock(RefundDistributor::class),
+            new NullLogger()
+        );
+    }
+
+    /**
+     * Quote-item trees, exactly as Magento stores them.
+     *
+     * 'items'    keyed by tax-calculation id; 'parent' refers to another key.
+     * 'mapped'   the codes that reach the tax details. A configurable's child is
+     *            absent on purpose: Magento never maps it, which is why it has
+     *            no tax-calculation id to be keyed by.
+     * 'expected' [sku, qty, price] per emitted cart line, in order.
+     */
+    public static function quoteShapeProvider(): array
+    {
+        return [
+            'simple' => [
+                'items' => [
+                    'p' => ['sku' => 'test-product', 'qty' => 1, 'price' => 10.0],
+                ],
+                'mapped' => ['p'],
+                'expected' => [['test-product', 1.0, 10.0]],
+            ],
+            'virtual' => [
+                'items' => [
+                    'p' => ['sku' => 'test-virtual', 'qty' => 1, 'price' => 10.0],
+                ],
+                'mapped' => ['p'],
+                'expected' => [['test-virtual', 1.0, 10.0]],
+            ],
+            'downloadable' => [
+                'items' => [
+                    'p' => ['sku' => 'test-downloadable', 'qty' => 1, 'price' => 10.0],
+                ],
+                'mapped' => ['p'],
+                'expected' => [['test-downloadable', 1.0, 10.0]],
+            ],
+            // A grouped product never reaches the quote: each association is its
+            // own top-level line carrying its own absolute qty.
+            'grouped' => [
+                'items' => [
+                    'a' => ['sku' => 'test-product', 'qty' => 1, 'price' => 10.0],
+                    'b' => ['sku' => 'test-virtual', 'qty' => 1, 'price' => 10.0],
+                ],
+                'mapped' => ['a', 'b'],
+                'expected' => [['test-product', 1.0, 10.0], ['test-virtual', 1.0, 10.0]],
+            ],
+            // Parent priced, child at 0 and never mapped. The parent's sku is the
+            // chosen variant's, which is what TaxCloud should hear about.
+            'configurable' => [
+                'items' => [
+                    'p' => ['sku' => 'test-variant-red', 'qty' => 1, 'price' => 10.0, 'children' => ['c']],
+                    'c' => ['sku' => 'test-variant-red', 'qty' => 1, 'price' => 0.0, 'parent' => 'p'],
+                ],
+                'mapped' => ['p'],
+                'expected' => [['test-variant-red', 1.0, 10.0]],
+            ],
+            // The regression. Selections carry the basis and store qty PER
+            // bundle, so a qty-3 cart is 3 and 6 units, never 1 and 2.
+            'bundle dynamic' => [
+                'items' => [
+                    'p' => [
+                        'sku' => 'test-bundle-dynamic',
+                        'qty' => 3,
+                        'price' => 30.0,
+                        'children' => ['c1', 'c2'],
+                        'childrenCalculated' => true,
+                    ],
+                    'c1' => ['sku' => 'test-product', 'qty' => 1, 'price' => 10.0, 'parent' => 'p'],
+                    'c2' => ['sku' => 'test-virtual', 'qty' => 2, 'price' => 10.0, 'parent' => 'p'],
+                ],
+                'mapped' => ['p', 'c1', 'c2'],
+                'expected' => [['test-product', 3.0, 10.0], ['test-virtual', 6.0, 10.0]],
+            ],
+            // The inverse: the parent holds the whole price and the selection is
+            // priced at 0, so only the parent is a cart line.
+            'bundle fixed' => [
+                'items' => [
+                    'p' => ['sku' => 'test-bundle-fixed', 'qty' => 1, 'price' => 50.0, 'children' => ['c']],
+                    'c' => ['sku' => 'test-product', 'qty' => 1, 'price' => 0.0, 'parent' => 'p'],
+                ],
+                'mapped' => ['p'],
+                'expected' => [['test-bundle-fixed', 1.0, 50.0]],
+            ],
+            'giftcard' => [
+                'items' => [
+                    'p' => ['sku' => 'test-giftcard', 'qty' => 1, 'price' => 25.0],
+                ],
+                'mapped' => ['p'],
+                'expected' => [['test-giftcard', 1.0, 25.0]],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider quoteShapeProvider
+     */
+    #[DataProvider('quoteShapeProvider')]
+    public function testLookupCartLinesForEachCatalogType(array $items, array $mapped, array $expected): void
+    {
+        $quoteItems = $this->buildQuoteTree($items);
+
+        $keyed = [];
+        $itemsByType = ['product' => []];
+        foreach ($mapped as $code) {
+            $keyed[$code] = $quoteItems[$code];
+            $itemsByType['product'][$code] = ['item' => 'x'];
+        }
+
+        $address = $this->getMockBuilder(Dbl\QuoteAddressDouble::class)
+            ->disableOriginalConstructor()->onlyMethods(['getShippingAmount'])->getMock();
+        $address->method('getShippingAmount')->willReturn(0.0);
+
+        $built = $this->builder->buildLookupCartItems($itemsByType, $keyed, $address);
+
+        $this->assertSame($expected, $this->linesOf($built['cartItems']));
+    }
+
+    /**
+     * Order-side trees. The same carts, after conversion — where a composite
+     * child's quantity is stored absolutely rather than per parent.
+     *
+     * 'visible'  what getAllVisibleItems() returns; children nest under it.
+     * 'expected' [sku, qty, price] per emitted cart line.
+     */
+    public static function orderShapeProvider(): array
+    {
+        return [
+            'simple' => [
+                'visible' => [['sku' => 'test-product', 'qty' => 1.0, 'price' => 10.0]],
+                'expected' => [['test-product', 1.0, 10.0]],
+            ],
+            'virtual' => [
+                'visible' => [['sku' => 'test-virtual', 'qty' => 1.0, 'price' => 10.0]],
+                'expected' => [['test-virtual', 1.0, 10.0]],
+            ],
+            'downloadable' => [
+                'visible' => [['sku' => 'test-downloadable', 'qty' => 1.0, 'price' => 10.0]],
+                'expected' => [['test-downloadable', 1.0, 10.0]],
+            ],
+            'grouped' => [
+                'visible' => [
+                    ['sku' => 'test-product', 'qty' => 1.0, 'price' => 10.0],
+                    ['sku' => 'test-virtual', 'qty' => 1.0, 'price' => 10.0],
+                ],
+                'expected' => [['test-product', 1.0, 10.0], ['test-virtual', 1.0, 10.0]],
+            ],
+            'configurable' => [
+                'visible' => [['sku' => 'test-variant-red', 'qty' => 1.0, 'price' => 10.0]],
+                'expected' => [['test-variant-red', 1.0, 10.0]],
+            ],
+            // qty_ordered on the children is already 3 and 6 — the quote side's
+            // multiplication has happened at conversion, and must not happen twice.
+            'bundle dynamic' => [
+                'visible' => [[
+                    'sku' => 'test-bundle-dynamic',
+                    'qty' => 3.0,
+                    'price' => 30.0,
+                    'childrenCalculated' => true,
+                    'children' => [
+                        ['sku' => 'test-product', 'qty' => 3.0, 'price' => 10.0],
+                        ['sku' => 'test-virtual', 'qty' => 6.0, 'price' => 10.0],
+                    ],
+                ]],
+                'expected' => [['test-product', 3.0, 10.0], ['test-virtual', 6.0, 10.0]],
+            ],
+            'bundle fixed' => [
+                'visible' => [[
+                    'sku' => 'test-bundle-fixed',
+                    'qty' => 1.0,
+                    'price' => 50.0,
+                    'children' => [['sku' => 'test-product', 'qty' => 1.0, 'price' => 0.0]],
+                ]],
+                'expected' => [['test-bundle-fixed', 1.0, 50.0]],
+            ],
+            'giftcard' => [
+                'visible' => [['sku' => 'test-giftcard', 'qty' => 1.0, 'price' => 25.0]],
+                'expected' => [['test-giftcard', 1.0, 25.0]],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider orderShapeProvider
+     */
+    #[DataProvider('orderShapeProvider')]
+    public function testOrderCartLinesForEachCatalogType(array $visible, array $expected): void
+    {
+        $order = $this->createMock(Order::class);
+        $order->method('getAllVisibleItems')->willReturn($this->buildOrderTree($visible));
+        $order->method('getBaseShippingAmount')->willReturn(0.0);
+
+        $cartItems = $this->builder->buildCartItemsFromOrder($order);
+
+        $this->assertSame($expected, $this->linesOf($cartItems));
+    }
+
+    /**
+     * A full refund must return exactly what the order authorized. The credit
+     * memo lists parents and children alike, so this is where a composite gets
+     * counted twice if the wrapper is not skipped.
+     *
+     * @dataProvider orderShapeProvider
+     */
+    #[DataProvider('orderShapeProvider')]
+    public function testReturnCartLinesMatchTheOrderForEachCatalogType(array $visible, array $expected): void
+    {
+        $orderItems = $this->buildOrderTree($visible);
+
+        // A credit memo item per order item, parents and children both.
+        $creditItems = [];
+        foreach ($orderItems as $orderItem) {
+            foreach (array_merge([$orderItem], $orderItem->getChildrenItems()) as $item) {
+                $credit = $this->createMock(CreditmemoItem::class);
+                $credit->method('getOrderItem')->willReturn($item);
+                $credit->method('getQty')->willReturn((float) $item->getQtyOrdered());
+                $credit->method('getPrice')->willReturn((float) $item->getPrice());
+                $credit->method('getDiscountAmount')->willReturn(0.0);
+                $creditItems[] = $credit;
+            }
+        }
+
+        $creditmemo = $this->createMock(Creditmemo::class);
+        $creditmemo->method('getOrder')->willReturn($this->createMock(Order::class));
+        $creditmemo->method('getAllItems')->willReturn($creditItems);
+        $creditmemo->method('getShippingAmount')->willReturn(0.0);
+
+        $return = $this->builder->buildReturnCartItems($creditmemo);
+
+        // No filtering here on purpose. A credit memo lists the $0 children of a
+        // parent-priced composite too, and the builder is expected to drop them:
+        // the Lookup never sent them, so returning them would name item IDs the
+        // order never reported. An integration invariant caught that divergence
+        // after this table was first written passing a filtered comparison.
+        $this->assertSame($expected, $this->linesOf($return['cartItems']));
+    }
+
+    /**
+     * The asymmetry, stated as an assertion: the same cart described from the
+     * quote and from the order must name the same SKUs at the same quantities.
+     * A quote child stores qty per parent and an order child stores it
+     * absolutely, so exactly one of the two sides has to multiply — and this is
+     * what fails if that ever gets applied to both or neither.
+     */
+    public function testQuoteAndOrderDescribeTheSameCart(): void
+    {
+        $quoteShapes = self::quoteShapeProvider();
+        $orderShapes = self::orderShapeProvider();
+
+        foreach ($quoteShapes as $label => $quoteShape) {
+            $this->assertSame(
+                $quoteShape['expected'],
+                $orderShapes[$label]['expected'],
+                "quote and order disagree about the lines for: $label"
+            );
+        }
+    }
+
+    /**
+     * Reduce cart items to [sku, qty, price] for comparison.
+     */
+    private function linesOf(array $cartItems): array
+    {
+        return array_map(
+            fn ($item) => [$item['ItemID'], (float) $item['Qty'], round((float) $item['Price'], 4)],
+            array_values(array_filter($cartItems, fn ($item) => $item['ItemID'] !== 'shipping'))
+        );
+    }
+
+    /**
+     * Turn a declarative quote tree into wired mocks. Parents and children point
+     * at each other, so both are resolved lazily against the finished map.
+     */
+    private function buildQuoteTree(array $declarations): array
+    {
+        $items = [];
+        $childrenOf = [];
+        foreach ($declarations as $code => $declaration) {
+            if (!empty($declaration['parent'])) {
+                $childrenOf[$declaration['parent']][] = $code;
+            }
+        }
+
+        foreach ($declarations as $code => $declaration) {
+            $product = $this->getMockBuilder(Dbl\ProductDouble::class)
+                ->disableOriginalConstructor()->onlyMethods(['getTaxClassId'])->getMock();
+            $product->method('getTaxClassId')->willReturn('2');
+
+            $item = $this->getMockBuilder(Dbl\QuoteItemDouble::class)
+                ->disableOriginalConstructor()
+                ->onlyMethods([
+                    'getProduct', 'getSku', 'getPrice', 'getDiscountAmount', 'getQty',
+                    'getParentItem', 'getChildren', 'isChildrenCalculated',
+                ])
+                ->getMock();
+            $item->method('getProduct')->willReturn($product);
+            $item->method('getSku')->willReturn($declaration['sku']);
+            $item->method('getPrice')->willReturn($declaration['price']);
+            $item->method('getDiscountAmount')->willReturn($declaration['discount'] ?? 0.0);
+            $item->method('getQty')->willReturn($declaration['qty']);
+            $item->method('isChildrenCalculated')->willReturn($declaration['childrenCalculated'] ?? false);
+            $item->method('getParentItem')->willReturnCallback(
+                function () use (&$items, $declaration) {
+                    return empty($declaration['parent']) ? null : $items[$declaration['parent']];
+                }
+            );
+            $item->method('getChildren')->willReturnCallback(
+                function () use (&$items, $childrenOf, $code) {
+                    return array_map(fn ($child) => $items[$child], $childrenOf[$code] ?? []);
+                }
+            );
+
+            $items[$code] = $item;
+        }
+
+        return $items;
+    }
+
+    /**
+     * Turn a declarative order tree into mocks, children first so a parent can
+     * hand them back.
+     */
+    private function buildOrderTree(array $declarations): array
+    {
+        $visible = [];
+        foreach ($declarations as $declaration) {
+            $children = [];
+            foreach ($declaration['children'] ?? [] as $childDeclaration) {
+                $children[] = $this->orderItem($childDeclaration, 1, $declaration['childrenCalculated'] ?? false);
+            }
+            $visible[] = $this->orderItem($declaration, null, $declaration['childrenCalculated'] ?? false, $children);
+        }
+
+        return $visible;
+    }
+
+    private function orderItem(array $declaration, $parentItemId, bool $childrenCalculated, array $children = [])
+    {
+        $item = $this->createMock(OrderItem::class);
+        $item->method('getSku')->willReturn($declaration['sku']);
+        $item->method('getQtyOrdered')->willReturn($declaration['qty']);
+        $item->method('getPrice')->willReturn($declaration['price']);
+        $item->method('getDiscountAmount')->willReturn($declaration['discount'] ?? 0.0);
+        $item->method('getParentItemId')->willReturn($parentItemId);
+        $item->method('isChildrenCalculated')->willReturn($childrenCalculated);
+        $item->method('getChildrenItems')->willReturn($children);
+
+        return $item;
+    }
+}

--- a/Test/Unit/Model/Gateway/RequestBuilderTest.php
+++ b/Test/Unit/Model/Gateway/RequestBuilderTest.php
@@ -141,6 +141,71 @@ class RequestBuilderTest extends TestCase
         $this->assertSame([], $this->builder->buildCartItemsFromOrder($order));
     }
 
+    /**
+     * An order item stubbed for the return / cancel payloads.
+     */
+    private function returnOrderItem(
+        string $sku,
+        $qtyOrdered,
+        $price,
+        $discount = 0.0,
+        $parentItemId = null,
+        bool $childrenCalculated = false,
+        array $children = []
+    ) {
+        $item = $this->createMock(OrderItem::class);
+        $item->method('getSku')->willReturn($sku);
+        $item->method('getQtyOrdered')->willReturn($qtyOrdered);
+        $item->method('getPrice')->willReturn($price);
+        $item->method('getDiscountAmount')->willReturn($discount);
+        $item->method('getParentItemId')->willReturn($parentItemId);
+        $item->method('isChildrenCalculated')->willReturn($childrenCalculated);
+        $item->method('getChildrenItems')->willReturn($children);
+
+        return $item;
+    }
+
+    /**
+     * The order side stores a bundle child's qty absolutely (qty_ordered 2 for
+     * the same line the quote stored as 1), so the children are emitted as they
+     * stand — multiplying here would double it back.
+     */
+    public function testBuildCartItemsFromOrderExpandsDynamicBundleIntoChildren()
+    {
+        $childA = $this->returnOrderItem('child-a', 2.0, 10.0, 0.0, 54, true);
+        $childB = $this->returnOrderItem('child-b', 2.0, 10.0, 0.0, 54, true);
+        $parent = $this->returnOrderItem('bundle-sku', 2.0, 20.0, 0.0, null, true, [$childA, $childB]);
+
+        $this->productTicService->method('getProductTic')->willReturn('20000');
+
+        $order = $this->createMock(Order::class);
+        $order->method('getAllVisibleItems')->willReturn([$parent]);
+        $order->method('getBaseShippingAmount')->willReturn(0.0);
+
+        $cartItems = $this->builder->buildCartItemsFromOrder($order);
+
+        $this->assertCount(2, $cartItems, 'the bundle wrapper must not add a third line');
+        $this->assertSame(['child-a', 'child-b'], array_column($cartItems, 'ItemID'));
+        $this->assertSame([2.0, 2.0], array_column($cartItems, 'Qty'));
+        $this->assertSame([0, 1], array_column($cartItems, 'Index'));
+    }
+
+    public function testBuildCartItemsFromOrderFallsBackToBundleParentWithoutChildren()
+    {
+        $parent = $this->returnOrderItem('bundle-sku', 2.0, 20.0, 0.0, null, true, []);
+
+        $this->productTicService->method('getProductTic')->willReturn('20000');
+
+        $order = $this->createMock(Order::class);
+        $order->method('getAllVisibleItems')->willReturn([$parent]);
+        $order->method('getBaseShippingAmount')->willReturn(0.0);
+
+        $cartItems = $this->builder->buildCartItemsFromOrder($order);
+
+        $this->assertCount(1, $cartItems);
+        $this->assertSame('bundle-sku', $cartItems[0]['ItemID']);
+    }
+
     public function testBuildDestinationFromOrderReturnsNullForNonUs()
     {
         $address = $this->createMock(OrderAddress::class);
@@ -359,6 +424,161 @@ class RequestBuilderTest extends TestCase
         $this->assertSame([], $built['cartItems']);
     }
 
+    /**
+     * A quote item stubbed with everything buildLookupCartItems() reads,
+     * including the composite hierarchy.
+     */
+    private function lookupQuoteItem(
+        string $sku,
+        $qty,
+        $price,
+        $discount = 0.0,
+        $parent = null,
+        $children = [],
+        bool $childrenCalculated = false
+    ) {
+        $product = $this->getMockBuilder(\Taxcloud\Magento2\Test\Unit\Double\ProductDouble::class)
+            ->disableOriginalConstructor()->onlyMethods(['getTaxClassId'])->getMock();
+        $product->method('getTaxClassId')->willReturn('2');
+
+        $item = $this->getMockBuilder(\Taxcloud\Magento2\Test\Unit\Double\QuoteItemDouble::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'getProduct',
+                'getSku',
+                'getPrice',
+                'getDiscountAmount',
+                'getQty',
+                'getParentItem',
+                'getChildren',
+                'isChildrenCalculated',
+            ])
+            ->getMock();
+        $item->method('getProduct')->willReturn($product);
+        $item->method('getSku')->willReturn($sku);
+        $item->method('getPrice')->willReturn($price);
+        $item->method('getDiscountAmount')->willReturn($discount);
+        $item->method('getQty')->willReturn($qty);
+        $item->method('getParentItem')->willReturn($parent);
+        $item->method('isChildrenCalculated')->willReturn($childrenCalculated);
+        // A parent and its children reference each other, so the children of a
+        // parent built first arrive late — accept a provider for that case.
+        if (is_callable($children)) {
+            $item->method('getChildren')->willReturnCallback($children);
+        } else {
+            $item->method('getChildren')->willReturn($children);
+        }
+
+        return $item;
+    }
+
+    /**
+     * A dynamic-price bundle as the quote stores it: the parent priced at the
+     * sum of its selections, the child holding the real price at a qty that is
+     * per-parent. Returns [parent, child].
+     */
+    private function dynamicBundleQuoteItems($parentQty, $childQty, $childPrice, $childDiscount = 0.0)
+    {
+        $children = [];
+
+        $parent = $this->lookupQuoteItem(
+            'bundle-sku',
+            $parentQty,
+            $childPrice * $childQty,
+            0.0,
+            null,
+            function () use (&$children) {
+                return $children;
+            },
+            true
+        );
+        $child = $this->lookupQuoteItem('child-sku', $childQty, $childPrice, $childDiscount, $parent);
+        $children[] = $child;
+
+        return [$parent, $child];
+    }
+
+    private function lookupAddress()
+    {
+        $address = $this->getMockBuilder(\Taxcloud\Magento2\Test\Unit\Double\QuoteAddressDouble::class)
+            ->disableOriginalConstructor()->onlyMethods(['getShippingAmount'])->getMock();
+        $address->method('getShippingAmount')->willReturn(0.0);
+
+        return $address;
+    }
+
+    /**
+     * Wrap quote items (keyed by tax-calculation id) in the two arguments
+     * buildLookupCartItems() takes.
+     */
+    private function buildLookupFor(array $keyedItems)
+    {
+        $this->productTicService->method('getProductTic')->willReturn('20000');
+
+        $itemsByType = ['product' => []];
+        foreach (array_keys($keyedItems) as $code) {
+            $itemsByType['product'][$code] = ['item' => 'x'];
+        }
+
+        return $this->builder->buildLookupCartItems($itemsByType, $keyedItems, $this->lookupAddress());
+    }
+
+    /**
+     * A qty-2 dynamic bundle holding one $10 selection: the quote stores the
+     * child at qty 1 against a $20 row total, so the cart line has to say 2.
+     * Sending 1 is what under-charged the customer by half.
+     */
+    public function testBuildLookupCartItemsMultipliesBundleChildQtyByParentQty()
+    {
+        [$parent, $child] = $this->dynamicBundleQuoteItems(2.0, 1.0, 10.0);
+
+        $built = $this->buildLookupFor(['bundle' => $parent, 'child' => $child]);
+
+        $this->assertCount(1, $built['cartItems'], 'the parent must not be a line of its own');
+        $this->assertSame('child-sku', $built['cartItems'][0]['ItemID']);
+        $this->assertSame(2.0, $built['cartItems'][0]['Qty']);
+        $this->assertSame(10.0, $built['cartItems'][0]['Price']);
+        $this->assertSame(['child'], array_values($built['indexedItems']));
+    }
+
+    public function testBuildLookupCartItemsSpreadsBundleChildDiscountOverEffectiveQty()
+    {
+        // $4 off the row, which is 2 units — $2 each, not $4.
+        [$parent, $child] = $this->dynamicBundleQuoteItems(2.0, 1.0, 10.0, 4.0);
+
+        $built = $this->buildLookupFor(['bundle' => $parent, 'child' => $child]);
+
+        $this->assertSame(8.0, $built['cartItems'][0]['Price']);
+        $this->assertSame(2.0, $built['cartItems'][0]['Qty']);
+    }
+
+    /**
+     * A configurable (and a fixed-price bundle) prices the parent and zeroes the
+     * children, so the parent stays the cart line and its qty is taken as-is.
+     */
+    public function testBuildLookupCartItemsKeepsConfigurableParentLine()
+    {
+        $child = $this->lookupQuoteItem('variant-sku', 1.0, 0.0);
+        $parent = $this->lookupQuoteItem('config-sku', 2.0, 10.0, 0.0, null, [$child], false);
+
+        $built = $this->buildLookupFor(['config' => $parent]);
+
+        $this->assertCount(1, $built['cartItems']);
+        $this->assertSame('config-sku', $built['cartItems'][0]['ItemID']);
+        $this->assertSame(2.0, $built['cartItems'][0]['Qty']);
+    }
+
+    public function testBuildLookupCartItemsSurvivesZeroQty()
+    {
+        $item = $this->lookupQuoteItem('SKU-1', 0.0, 10.0, 5.0);
+
+        $built = $this->buildLookupFor(['p1' => $item]);
+
+        // Regression: the discount used to be divided by qty unguarded.
+        $this->assertSame(10.0, $built['cartItems'][0]['Price']);
+        $this->assertSame(0.0, $built['cartItems'][0]['Qty']);
+    }
+
     public function testBuildLookupParams()
     {
         $customer = $this->createMock(\Magento\Customer\Api\Data\CustomerInterface::class);
@@ -484,6 +704,43 @@ class RequestBuilderTest extends TestCase
         $this->assertSame('SKU-1', $return['cartItems'][0]['ItemID']);
         $this->assertSame(8.0, $return['cartItems'][0]['Price']); // 10 - 4/2
         $this->assertSame('shipping', $return['cartItems'][1]['ItemID']);
+    }
+
+    /**
+     * Refunding a dynamic bundle: the children are credit-memo items in their
+     * own right, so returning the wrapper as well would hand back tax on twice
+     * the basis that was authorized.
+     */
+    public function testBuildReturnCartItemsSkipsDynamicBundleParent()
+    {
+        $parentOrderItem = $this->returnOrderItem('bundle-sku', 2.0, 20.0, 0.0, null, true);
+        $childOrderItem = $this->returnOrderItem('child-sku', 2.0, 10.0, 0.0, 54, true);
+
+        $parentCredit = $this->createMock(\Magento\Sales\Model\Order\Creditmemo\Item::class);
+        $parentCredit->method('getQty')->willReturn(2.0);
+        $parentCredit->method('getOrderItem')->willReturn($parentOrderItem);
+        $parentCredit->method('getPrice')->willReturn(20.0);
+        $parentCredit->method('getDiscountAmount')->willReturn(0.0);
+
+        $childCredit = $this->createMock(\Magento\Sales\Model\Order\Creditmemo\Item::class);
+        $childCredit->method('getQty')->willReturn(2.0);
+        $childCredit->method('getOrderItem')->willReturn($childOrderItem);
+        $childCredit->method('getPrice')->willReturn(10.0);
+        $childCredit->method('getDiscountAmount')->willReturn(0.0);
+
+        $this->productTicService->method('getProductTic')->willReturn('20000');
+
+        $creditmemo = $this->createMock(\Magento\Sales\Model\Order\Creditmemo::class);
+        $creditmemo->method('getOrder')->willReturn($this->createMock(Order::class));
+        $creditmemo->method('getAllItems')->willReturn([$parentCredit, $childCredit]);
+        $creditmemo->method('getShippingAmount')->willReturn(0.0);
+
+        $return = $this->builder->buildReturnCartItems($creditmemo);
+
+        $this->assertCount(1, $return['cartItems']);
+        $this->assertSame('child-sku', $return['cartItems'][0]['ItemID']);
+        $this->assertSame(2.0, $return['cartItems'][0]['Qty'], 'order-side qty is already absolute');
+        $this->assertSame(0, $return['cartItems'][0]['Index']);
     }
 
     public function testBuildReturnCartItemsDetectsTaxOnlyRefund()

--- a/Test/Unit/Model/TaxTest.php
+++ b/Test/Unit/Model/TaxTest.php
@@ -395,6 +395,167 @@ class TaxTest extends TestCase
     }
 
     /**
+     * Helper: a quote item wired into a composite hierarchy, for the bundle
+     * cases below. $children may be a closure, since a parent built before its
+     * children still has to hand them back.
+     */
+    private function createMockCompositeQuoteItem(
+        $itemId,
+        $qty,
+        $price,
+        $rowTotal,
+        $parent = null,
+        $children = [],
+        $childrenCalculated = false
+    ) {
+        $item = $this->getMockBuilder(Dbl\QuoteItemDouble::class)
+            ->onlyMethods([
+                'getPrice', 'getProduct', 'getQty', 'getBasePrice', 'getBaseRowTotal', 'getRowTotal',
+                'getTaxCalculationItemId', 'setBasePriceInclTax', 'setBaseRowTotalInclTax', 'setBaseTaxAmount',
+                'setPriceInclTax', 'setRowTotalInclTax', 'setTaxAmount', 'setTaxPercent',
+                'getParentItem', 'getChildren', 'isChildrenCalculated',
+            ])
+            ->getMock();
+
+        $product = $this->getMockBuilder(Dbl\ProductDouble::class)
+            ->onlyMethods(['getTaxClassId'])
+            ->getMock();
+        $product->method('getTaxClassId')->willReturn('2');
+
+        $item->method('getTaxCalculationItemId')->willReturn($itemId);
+        $item->method('getProduct')->willReturn($product);
+        $item->method('getQty')->willReturn($qty);
+        $item->method('getPrice')->willReturn($price);
+        $item->method('getBasePrice')->willReturn($price);
+        $item->method('getRowTotal')->willReturn($rowTotal);
+        $item->method('getBaseRowTotal')->willReturn($rowTotal);
+        $item->method('getParentItem')->willReturn($parent);
+        $item->method('isChildrenCalculated')->willReturn($childrenCalculated);
+        if (is_callable($children)) {
+            $item->method('getChildren')->willReturnCallback($children);
+        } else {
+            $item->method('getChildren')->willReturn($children);
+        }
+
+        return $item;
+    }
+
+    /**
+     * A qty-2 dynamic bundle holding one $10 selection, as the quote stores it:
+     * the child at qty 1 against a $20 row total. Returns [parent, child].
+     */
+    private function createDynamicBundleQuoteItems()
+    {
+        $children = [];
+
+        $parent = $this->createMockCompositeQuoteItem(
+            'bundle-1',
+            2,
+            10.00,
+            20.00,
+            null,
+            function () use (&$children) {
+                return $children;
+            },
+            true
+        );
+        $child = $this->createMockCompositeQuoteItem('child-1', 1, 10.00, 20.00, $parent);
+        $children[] = $child;
+
+        return [$parent, $child];
+    }
+
+    /**
+     * The regression, at the collector: a bundle child's per-parent qty must not
+     * be what the per-unit incl-tax price is derived from, or the $20 row shows
+     * the tax of a single $10 unit.
+     */
+    public function testCollectSpreadsBundleChildTaxOverTheParentMultipliedQty()
+    {
+        $this->configureTaxCloudEnabled();
+
+        [$parent, $child] = $this->createDynamicBundleQuoteItems();
+
+        $quote = $this->createMockQuote();
+        $shippingAssignment = $this->createMock(ShippingAssignmentInterface::class);
+        $shippingAssignment->method('getItems')->willReturn([$parent, $child]);
+
+        $total = $this->getMockBuilder(Dbl\TotalDouble::class)
+            ->onlyMethods(['getBaseTaxAmount', 'getTaxAmount'])
+            ->getMock();
+        $total->method('getTaxAmount')->willReturn(0);
+        $total->method('getBaseTaxAmount')->willReturn(0);
+
+        [$parentDetail, $parentBaseDetail] = $this->createMockTaxDetails(10.00, 20.00);
+        [$childDetail, $childBaseDetail] = $this->createMockTaxDetails(10.00, 20.00);
+        $itemsByType = [
+            Tax::ITEM_TYPE_PRODUCT => [
+                'bundle-1' => [Tax::KEY_ITEM => $parentDetail, Tax::KEY_BASE_ITEM => $parentBaseDetail],
+                'child-1' => [Tax::KEY_ITEM => $childDetail, Tax::KEY_BASE_ITEM => $childBaseDetail],
+            ],
+        ];
+
+        $this->setupParentMethodMocks($itemsByType);
+        // Only the child is sent to TaxCloud, so only the child comes back.
+        $this->setupTaxCloudApiMock(['child-1' => 1.65], 0);
+
+        $child->expects($this->once())->method('setTaxAmount')->with($this->equalTo(1.65));
+        // 8.25% of the $20 row — not the 4.15% a half-priced lookup produced.
+        $child->expects($this->once())->method('setTaxPercent')->with($this->equalTo(8.25));
+        // 10 + 1.65/2, i.e. the tax of one unit on one unit's price.
+        $child->expects($this->once())->method('setPriceInclTax')->with($this->equalTo(10.825));
+        $child->expects($this->once())->method('setRowTotalInclTax')->with($this->equalTo(21.65));
+
+        $this->tax->collect($quote, $shippingAssignment, $total);
+    }
+
+    /**
+     * The bundle parent is never sent to TaxCloud, so the tax it displays can
+     * only be its children's — and it must stay out of the total, exactly as
+     * Magento's own processProductItems() leaves it out.
+     */
+    public function testCollectShowsBundleParentTaxAsSumOfChildrenWithoutDoubleCounting()
+    {
+        $this->configureTaxCloudEnabled(logging: true);
+
+        [$parent, $child] = $this->createDynamicBundleQuoteItems();
+
+        $quote = $this->createMockQuote();
+        $shippingAssignment = $this->createMock(ShippingAssignmentInterface::class);
+        $shippingAssignment->method('getItems')->willReturn([$parent, $child]);
+
+        $total = $this->getMockBuilder(Dbl\TotalDouble::class)
+            ->onlyMethods([
+                'addBaseTotalAmount', 'addTotalAmount', 'getBaseTaxAmount',
+                'getTaxAmount', 'setBaseTaxAmount', 'setTaxAmount',
+            ])
+            ->getMock();
+        $total->method('getTaxAmount')->willReturn(0.0);
+        $total->method('getBaseTaxAmount')->willReturn(0.0);
+
+        [$parentDetail, $parentBaseDetail] = $this->createMockTaxDetails(10.00, 20.00);
+        [$childDetail, $childBaseDetail] = $this->createMockTaxDetails(10.00, 20.00);
+        $itemsByType = [
+            Tax::ITEM_TYPE_PRODUCT => [
+                'bundle-1' => [Tax::KEY_ITEM => $parentDetail, Tax::KEY_BASE_ITEM => $parentBaseDetail],
+                'child-1' => [Tax::KEY_ITEM => $childDetail, Tax::KEY_BASE_ITEM => $childBaseDetail],
+            ],
+        ];
+
+        $this->setupParentMethodMocks($itemsByType);
+        $this->setupTaxCloudApiMock(['child-1' => 1.65], 0);
+
+        $parent->expects($this->once())->method('setTaxAmount')->with($this->equalTo(1.65));
+
+        // The safeguard adds the product tax once: 1.65, not the 3.30 that
+        // counting the parent's echo alongside its child would produce.
+        $total->expects($this->once())->method('addTotalAmount')->with('tax', 1.65);
+        $total->expects($this->once())->method('addBaseTotalAmount')->with('tax', 1.65);
+
+        $this->tax->collect($quote, $shippingAssignment, $total);
+    }
+
+    /**
      * Test defensive safeguard adds product tax when missing from totals
      */
     public function testDefensiveSafeguardAddsProductTaxToTotals()

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "taxcloud/magento2",
   "description": "TaxCloud Module for Magento 2",
   "type": "magento2-module",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "OSL-3.0",
   "autoload": {
     "files": [

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -17,7 +17,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Taxcloud_Magento2" setup_version="1.3.0">
+  <module name="Taxcloud_Magento2" setup_version="1.3.1">
     <sequence>
       <module name="Magento_Sales"/>
     </sequence>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -67,6 +67,7 @@
     <rule ref="Magento2.Functions.StaticFunction">
         <exclude-pattern>Model/PostalCodeParser\.php$</exclude-pattern>
         <exclude-pattern>Model/Logging/LogRedactor\.php$</exclude-pattern>
+        <exclude-pattern>Model/CompositeItemResolver\.php$</exclude-pattern>
     </rule>
 
     <!-- 1 finding: stream_context_create() flagged as an unguarded system-resource

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -55,16 +55,6 @@ parameters:
 			path: Model/Api.php
 
 		-
-			message: "#^Call to an undefined method Magento\\\\Quote\\\\Api\\\\Data\\\\CartItemInterface\\:\\:getDiscountAmount\\(\\)\\.$#"
-			count: 1
-			path: Model/Fallback/MagentoTaxFallback.php
-
-		-
-			message: "#^Call to an undefined method Magento\\\\Quote\\\\Api\\\\Data\\\\CartItemInterface\\:\\:getProduct\\(\\)\\.$#"
-			count: 2
-			path: Model/Fallback/MagentoTaxFallback.php
-
-		-
 			message: "#^Call to an undefined method Magento\\\\Quote\\\\Api\\\\Data\\\\CartItemInterface\\:\\:getTaxCalculationItemId\\(\\)\\.$#"
 			count: 1
 			path: Model/Fallback/MagentoTaxFallback.php
@@ -90,71 +80,6 @@ parameters:
 			path: Model/RefundDistributor.php
 
 		-
-			message: "#^Call to an undefined method Magento\\\\Quote\\\\Api\\\\Data\\\\CartItemInterface\\:\\:getBasePrice\\(\\)\\.$#"
-			count: 1
-			path: Model/Tax.php
-
-		-
-			message: "#^Call to an undefined method Magento\\\\Quote\\\\Api\\\\Data\\\\CartItemInterface\\:\\:getBaseRowTotal\\(\\)\\.$#"
-			count: 1
-			path: Model/Tax.php
-
-		-
-			message: "#^Call to an undefined method Magento\\\\Quote\\\\Api\\\\Data\\\\CartItemInterface\\:\\:getData\\(\\)\\.$#"
-			count: 6
-			path: Model/Tax.php
-
-		-
-			message: "#^Call to an undefined method Magento\\\\Quote\\\\Api\\\\Data\\\\CartItemInterface\\:\\:getProduct\\(\\)\\.$#"
-			count: 1
-			path: Model/Tax.php
-
-		-
-			message: "#^Call to an undefined method Magento\\\\Quote\\\\Api\\\\Data\\\\CartItemInterface\\:\\:getRowTotal\\(\\)\\.$#"
-			count: 1
-			path: Model/Tax.php
-
-		-
 			message: "#^Call to an undefined method Magento\\\\Quote\\\\Api\\\\Data\\\\CartItemInterface\\:\\:getTaxCalculationItemId\\(\\)\\.$#"
-			count: 1
-			path: Model/Tax.php
-
-		-
-			message: "#^Call to an undefined method Magento\\\\Quote\\\\Api\\\\Data\\\\CartItemInterface\\:\\:setBasePriceInclTax\\(\\)\\.$#"
-			count: 1
-			path: Model/Tax.php
-
-		-
-			message: "#^Call to an undefined method Magento\\\\Quote\\\\Api\\\\Data\\\\CartItemInterface\\:\\:setBaseRowTotalInclTax\\(\\)\\.$#"
-			count: 1
-			path: Model/Tax.php
-
-		-
-			message: "#^Call to an undefined method Magento\\\\Quote\\\\Api\\\\Data\\\\CartItemInterface\\:\\:setBaseTaxAmount\\(\\)\\.$#"
-			count: 1
-			path: Model/Tax.php
-
-		-
-			message: "#^Call to an undefined method Magento\\\\Quote\\\\Api\\\\Data\\\\CartItemInterface\\:\\:setData\\(\\)\\.$#"
-			count: 5
-			path: Model/Tax.php
-
-		-
-			message: "#^Call to an undefined method Magento\\\\Quote\\\\Api\\\\Data\\\\CartItemInterface\\:\\:setPriceInclTax\\(\\)\\.$#"
-			count: 1
-			path: Model/Tax.php
-
-		-
-			message: "#^Call to an undefined method Magento\\\\Quote\\\\Api\\\\Data\\\\CartItemInterface\\:\\:setRowTotalInclTax\\(\\)\\.$#"
-			count: 1
-			path: Model/Tax.php
-
-		-
-			message: "#^Call to an undefined method Magento\\\\Quote\\\\Api\\\\Data\\\\CartItemInterface\\:\\:setTaxAmount\\(\\)\\.$#"
-			count: 1
-			path: Model/Tax.php
-
-		-
-			message: "#^Call to an undefined method Magento\\\\Quote\\\\Api\\\\Data\\\\CartItemInterface\\:\\:setTaxPercent\\(\\)\\.$#"
 			count: 1
 			path: Model/Tax.php

--- a/scripts/enable-test-products.php
+++ b/scripts/enable-test-products.php
@@ -57,15 +57,30 @@ try {
     // area already set
 }
 
-// The full seeded catalog. Keep in sync with seed-test-data.php.
-$skus = ['test-product', 'test-variant-red', 'test-variant-blue', 'test-configurable'];
+// The full seeded catalog. Keep in sync with seed-test-data.php. test-giftcard
+// only exists on Adobe Commerce; a missing sku is skipped below, so listing it
+// unconditionally is safe.
+$skus = [
+    'test-product',
+    'test-variant-red',
+    'test-variant-blue',
+    'test-configurable',
+    'test-virtual',
+    'test-downloadable',
+    'test-grouped',
+    'test-bundle-dynamic',
+    'test-bundle-fixed',
+    'test-giftcard',
+];
 
 $productRepository = $om->get(\Magento\Catalog\Api\ProductRepositoryInterface::class);
 
 $ids = [];
+$found = [];
 foreach ($skus as $sku) {
     try {
         $ids[] = (int) $productRepository->get($sku)->getId();
+        $found[] = $sku;
     } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
         echo "[enable] skip $sku (not found)\n";
     }
@@ -82,4 +97,4 @@ $om->get(\Magento\Catalog\Model\Product\Action::class)->updateAttributes(
     0
 );
 
-echo '[enable] enabled ' . count($ids) . ' test products: ' . implode(', ', $skus) . "\n";
+echo '[enable] enabled ' . count($ids) . ' test products: ' . implode(', ', $found) . "\n";

--- a/scripts/install-magento.sh
+++ b/scripts/install-magento.sh
@@ -329,6 +329,18 @@ docker compose exec -T -w /var/www/html app \
 echo "==> Reindexing (fresh process, fixes configurable salability)..."
 docker compose exec -T -w /var/www/html app bin/magento indexer:reindex
 
+# --- 9b. Verify the seeded catalog is actually buyable ----------------------
+#
+# Every seeded product must load, be enabled, appear in the Test Category
+# listing, and add to a cart. This is the check that catches the failure modes
+# the two steps above exist to prevent (Content Staging leaving products
+# disabled, a stale salability index) — before a test suite runs and blames the
+# module for them. Fails the install loudly rather than leaving a half-usable
+# catalog behind.
+echo "==> Verifying seeded catalog (scripts/verify-test-products.php)..."
+docker compose exec -T -w /var/www/html app \
+    php /srv/module/scripts/verify-test-products.php
+
 # --- 10. E2E: reload nginx and confirm the storefront serves ---------------
 #
 # nginx came up before nginx.conf existed (so it started with an empty vhost).

--- a/scripts/seed-test-data.php
+++ b/scripts/seed-test-data.php
@@ -14,6 +14,13 @@
  *   - Configurable    "Test Configurable" (sku: test-configurable) with two
  *                     simple variants on a test_variant_color attribute:
  *                     test-variant-red (TIC 20010), test-variant-blue (TIC 00000)
+ *   - Every other     one product per remaining catalog type, all $10 and all on
+ *     catalog type    the store default TIC, so each quote-line shape is covered:
+ *                     test-virtual, test-downloadable, test-grouped (associates
+ *                     the simple + the virtual), test-bundle-dynamic ($30/bundle:
+ *                     1x test-product + 2x test-virtual, selections carry the
+ *                     price), test-bundle-fixed ($50 on the parent), and on
+ *                     Adobe Commerce only, test-giftcard ($25 virtual)
  *   - Config          tax/taxcloud_settings/* (enabled, logging,
  *                     verify_address, default_tic, api creds from env)
  *                     shipping/origin/*       (1401 Lavaca St, Austin TX)
@@ -29,13 +36,32 @@
  *   - Reindex all indexers, flush all caches
  *
  * Usage:
- *   php seed-test-data.php [magento-root]
+ *   php seed-test-data.php [magento-root] [--products-only] [--recreate[=sku,sku]]
  *
  * The Magento root is resolved from: argv[1], then $MAGENTO_ROOT, then the
  * current working directory, then this script's location under
  * app/code/Taxcloud/Magento2/scripts/.
  *
  * Required env vars: TAXCLOUD_API_ID, TAXCLOUD_API_KEY
+ *
+ * --products-only seeds ONLY the test category and the catalog above (plus the
+ * reindex and cache flush that make them visible). It writes no configuration,
+ * no admin user, no customer and no second website — which is what makes it
+ * safe to point at a working development store, where the rest of this script
+ * would overwrite live credentials, reset the admin password, rewrite every URL
+ * via web/url/use_store, and disable stock management globally. The API
+ * credentials are not required in this mode, since nothing reads them.
+ *
+ * --recreate deletes the seeded products before rebuilding them. Everything
+ * here is idempotent by SKU, which means an existing product is left ALONE —
+ * so a correction to how a product is built never reaches a store that already
+ * has the old one. That is what this flag is for. Narrow it to the type you are
+ * iterating on with --recreate=test-giftcard,test-bundle-fixed; with no list it
+ * drops the whole seeded catalog.
+ *
+ * Deleting is not free of consequences on a store with its own content: a
+ * hand-built bundle or grouped product that uses a seeded SKU as one of its
+ * selections loses that selection. Pass the list when that matters.
  */
 
 declare(strict_types=1);
@@ -48,8 +74,27 @@ error_reporting(E_ALL);
 
 // --- Locate and bootstrap Magento ------------------------------------------
 
+// Catalog only: leave this store's configuration, admin user, customers and
+// scope tree exactly as they are. See the usage note above for why.
+$options = array_values(array_filter($argv, static fn ($arg) => str_starts_with((string) $arg, '--')));
+$positional = array_values(array_filter(
+    array_slice($argv, 1),
+    static fn ($arg) => !str_starts_with((string) $arg, '--')
+));
+$productsOnly = in_array('--products-only', $options, true);
+
+// --recreate, or --recreate=sku,sku for a subset. null = not requested.
+$recreateSkus = null;
+foreach ($options as $option) {
+    if ($option === '--recreate') {
+        $recreateSkus = [];
+    } elseif (str_starts_with($option, '--recreate=')) {
+        $recreateSkus = array_values(array_filter(array_map('trim', explode(',', substr($option, 11)))));
+    }
+}
+
 $candidates = array_filter([
-    $argv[1] ?? null,
+    $positional[0] ?? null,
     getenv('MAGENTO_ROOT') ?: null,
     getcwd() ?: null,
     dirname(__DIR__, 5), // app/code/Taxcloud/Magento2/scripts -> magento root
@@ -71,7 +116,7 @@ if ($magentoRoot === null) {
 
 $apiId  = getenv('TAXCLOUD_API_ID');
 $apiKey = getenv('TAXCLOUD_API_KEY');
-if (!$apiId || !$apiKey) {
+if (!$productsOnly && (!$apiId || !$apiKey)) {
     fwrite(STDERR, "ERROR: TAXCLOUD_API_ID and TAXCLOUD_API_KEY must be set in the environment.\n");
     exit(1);
 }
@@ -102,31 +147,38 @@ const ADMIN_USERNAME = 'admin';
 const ADMIN_EMAIL    = 'admin@example.com';
 const ADMIN_PASSWORD = '1234567a';
 
-$roleCollection = $om->create(\Magento\Authorization\Model\ResourceModel\Role\CollectionFactory::class)
-    ->create()
-    ->addFieldToFilter('role_name', 'Administrators');
-$adminRoleId = (int) ($roleCollection->getFirstItem()->getId() ?: 1);
+if ($productsOnly) {
+    // Resetting an existing admin's password is exactly the kind of damage
+    // --products-only exists to avoid.
+    $step('skipped admin user (--products-only)');
+} else {
+    $roleCollection = $om->create(\Magento\Authorization\Model\ResourceModel\Role\CollectionFactory::class)
+        ->create()
+        ->addFieldToFilter('role_name', 'Administrators');
+    $adminRoleId = (int) ($roleCollection->getFirstItem()->getId() ?: 1);
 
-/** @var \Magento\User\Model\User $user */
-$user = $om->create(\Magento\User\Model\UserFactory::class)->create();
-$user->loadByUsername(ADMIN_USERNAME);
-$existed = (bool) $user->getId();
+    /** @var \Magento\User\Model\User $user */
+    $user = $om->create(\Magento\User\Model\UserFactory::class)->create();
+    $user->loadByUsername(ADMIN_USERNAME);
+    $existed = (bool) $user->getId();
 
-$user->setFirstname('Admin')
-    ->setLastname('User')
-    ->setUsername(ADMIN_USERNAME)
-    ->setEmail(ADMIN_EMAIL)
-    ->setPassword(ADMIN_PASSWORD)
-    ->setIsActive(1)
-    ->setRoleId($adminRoleId);
-$user->save();
+    $user->setFirstname('Admin')
+        ->setLastname('User')
+        ->setUsername(ADMIN_USERNAME)
+        ->setEmail(ADMIN_EMAIL)
+        ->setPassword(ADMIN_PASSWORD)
+        ->setIsActive(1)
+        ->setRoleId($adminRoleId);
+    $user->save();
 
-$step('admin user "' . ADMIN_USERNAME . '" <' . ADMIN_EMAIL . '> '
-    . ($existed ? 'updated' : 'created') . " (role $adminRoleId)");
+    $step('admin user "' . ADMIN_USERNAME . '" <' . ADMIN_EMAIL . '> '
+        . ($existed ? 'updated' : 'created') . " (role $adminRoleId)");
+}
 
 // --- 2. System configuration -------------------------------------------------
 
-$configValues = [
+// Empty in catalog-only mode, so the loop below writes nothing at all.
+$configValues = $productsOnly ? [] : [
     'tax/taxcloud_settings/enabled'        => '1',
     'tax/taxcloud_settings/logging'        => '1',
     'tax/taxcloud_settings/verify_address' => '1',
@@ -145,7 +197,13 @@ $configValues = [
     'carriers/flatrate/active' => '1',
     'payment/checkmo/active'   => '1',
 
-    // Store code in URLs so the default and second store (section 4d) are both
+    // Magento blocks guest checkout outright for any cart holding a downloadable
+    // product (default on), which would leave the seeded downloadable reachable
+    // only through a logged-in journey while every other type is testable as a
+    // guest. Off here so one checkout flow covers the whole catalog.
+    'catalog/downloadable/disable_guest_checkout' => '0',
+
+    // Store code in URLs so the default and second store (section 4i) are both
     // reachable on the same base URL as /default/... and /second/... — no extra
     // vhost/DNS needed for multi-store E2E navigation.
     'web/url/use_store' => '1',
@@ -162,6 +220,9 @@ $configValues = [
 // Go through PreparedValueFactory (what `bin/magento config:set` uses) so any
 // backend model attached to a field (e.g. encrypted values) is honored.
 $preparedValueFactory = $om->get(\Magento\Config\Model\PreparedValueFactory::class);
+if ($productsOnly) {
+    $step('skipped all system configuration (--products-only)');
+}
 foreach ($configValues as $path => $value) {
     $backendModel = $preparedValueFactory->create(
         $path,
@@ -212,6 +273,70 @@ const PRODUCT_PRICE = 10.00;
 
 /** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepository */
 $productRepository = $om->get(\Magento\Catalog\Api\ProductRepositoryInterface::class);
+
+// --- 4-pre. Drop seeded products so they are rebuilt -------------------------
+//
+// Composites first: deleting a selection out from under its parent leaves the
+// parent referencing a product that no longer exists.
+if ($recreateSkus !== null) {
+    $seededSkus = [
+        'test-bundle-dynamic',
+        'test-bundle-fixed',
+        'test-grouped',
+        'test-configurable',
+        'test-variant-red',
+        'test-variant-blue',
+        'test-giftcard',
+        'test-downloadable',
+        'test-virtual',
+        'test-product',
+    ];
+    $targets = $recreateSkus === []
+        ? $seededSkus
+        : array_values(array_intersect($seededSkus, $recreateSkus));
+
+    if ($unknown = array_diff($recreateSkus, $seededSkus)) {
+        // Refuse to delete anything this script did not create.
+        fwrite(STDERR, 'ERROR: --recreate only accepts SKUs this seed owns; not seeded: '
+            . implode(', ', $unknown) . "\n");
+        exit(1);
+    }
+
+    // deleteById() on a catalog product needs the secure area, the same guard
+    // the admin product grid sets before a mass delete.
+    $om->get(\Magento\Framework\Registry::class)->register('isSecureArea', true, true);
+
+    $connection = $om->get(\Magento\Framework\App\ResourceConnection::class)->getConnection();
+    $quoteItemTable = $connection->getTableName('quote_item');
+
+    foreach ($targets as $sku) {
+        try {
+            $productId = (int) $productRepository->get($sku)->getId();
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+            continue; // Never existed here; nothing to rebuild from.
+        }
+
+        // Take this product out of every cart BEFORE deleting it. Magento drops
+        // a quote line whose product has vanished, but it does not drop that
+        // line's CHILDREN — they keep a parent_item_id pointing at nothing. The
+        // orphan survives quietly until checkout, where resolveItems() hands the
+        // missing parent to ToOrderItem::convert() and the order dies on
+        // "Argument #2 ($quoteItem) must be of type AbstractItem, null given".
+        // Deleting a bundle or configurable that is sitting in a live cart is
+        // exactly how that happens.
+        $lineIds = $connection->fetchCol(
+            $connection->select()->from($quoteItemTable, 'item_id')->where('product_id = ?', $productId)
+        );
+        if ($lineIds) {
+            $connection->delete($quoteItemTable, ['parent_item_id IN (?)' => $lineIds]);
+            $connection->delete($quoteItemTable, ['item_id IN (?)' => $lineIds]);
+            $step('removed "' . $sku . '" from ' . count($lineIds) . ' cart line(s) before deleting it');
+        }
+
+        $productRepository->deleteById($sku);
+        $step('deleted "' . $sku . '" (--recreate)');
+    }
+}
 
 try {
     $productRepository->get(PRODUCT_SKU);
@@ -402,7 +527,364 @@ $step('configurable "' . CONFIGURABLE_SKU . "\" assigned to category $categoryId
 // runs it right after this seed. If you run this seed standalone on Enterprise,
 // run that script afterward (it's a harmless no-op on Open Source).
 
-// --- 4c. Registered customer + default address ------------------------------
+// --- 4c. One product per remaining type --------------------------------------
+//
+// Simple and configurable are covered above. The rest of Magento's catalog
+// types get one product each, so tax behaviour can be exercised against every
+// shape a quote line can take:
+//
+//   virtual / downloadable  — no shipping, so a cart of only these is assigned
+//                             to the BILLING address (Quote\Address::getAllItems)
+//   grouped                 — explodes into one independent line per associated
+//                             product; no parent line ever reaches the quote
+//   bundle (dynamic)        — the selections carry the price, and their quote qty
+//                             is stored PER BUNDLE; the parent is a wrapper
+//   bundle (fixed)          — the inverse: the parent carries the price and the
+//                             selections are priced at 0
+//   giftcard (Commerce)     — priced by the chosen amount; seeded only where the
+//                             module exists
+//
+// Every product is $10 (gift card $25) so expected tax stays easy to reason
+// about, and none carries its own TIC — they resolve through the store default
+// (20000), which keeps these lines independent of the TIC tests above.
+
+$defaultAttributeSetId = (int) $om->get(\Magento\Eav\Model\Config::class)
+    ->getEntityType(\Magento\Catalog\Model\Product::ENTITY)
+    ->getDefaultAttributeSetId();
+$defaultWebsiteId = (int) $storeManager->getDefaultStoreView()->getWebsiteId();
+
+/**
+ * A URL key for a seeded product that no existing product or category has
+ * already claimed.
+ *
+ * On a fresh install the SKU is free and becomes the key verbatim. Pointed at a
+ * store that already has its own catalog — which is the whole point of
+ * --products-only — a name collision is entirely possible, and Magento answers
+ * it with a bare "URL key for specified store already exists" that aborts the
+ * seed partway through. Stepping aside is better than failing.
+ */
+$uniqueUrlKey = function (string $sku) use ($om, $step): string {
+    $connection = $om->get(\Magento\Framework\App\ResourceConnection::class);
+    $table = $connection->getTableName('url_rewrite');
+
+    $taken = (bool) $connection->getConnection()->fetchOne(
+        $connection->getConnection()
+            ->select()
+            ->from($table, 'url_rewrite_id')
+            ->where('request_path = ?', $sku . '.html')
+            ->limit(1)
+    );
+
+    if (!$taken) {
+        return $sku;
+    }
+
+    $step('url key "' . $sku . '" is taken; seeding as "' . $sku . '-taxcloud"');
+
+    return $sku . '-taxcloud';
+};
+
+/**
+ * Create a product unless its SKU already exists, letting the caller shape the
+ * type-specific parts. Returns the product id either way. $configure receives
+ * the unsaved product and may return a replacement to save.
+ */
+$ensureProduct = function (
+    string $sku,
+    string $name,
+    string $typeId,
+    ?float $price,
+    ?callable $configure = null
+) use (
+    $om,
+    $productRepository,
+    $defaultAttributeSetId,
+    $defaultWebsiteId,
+    $categoryId,
+    $uniqueUrlKey,
+    $step
+): int {
+    try {
+        $existing = $productRepository->get($sku);
+        $step('product "' . $sku . '" already exists (' . $typeId . ')');
+        $om->get(\Magento\Catalog\Api\CategoryLinkManagementInterface::class)
+            ->assignProductToCategories($sku, [$categoryId]);
+        return (int) $existing->getId();
+    } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+        // fall through and create
+    }
+
+    /** @var \Magento\Catalog\Model\Product $product */
+    $product = $om->create(\Magento\Catalog\Model\ProductFactory::class)->create();
+    $product->setSku($sku)
+        ->setName($name)
+        ->setUrlKey($uniqueUrlKey($sku))
+        ->setTypeId($typeId)
+        ->setAttributeSetId($defaultAttributeSetId)
+        ->setStatus(\Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED)
+        ->setVisibility(\Magento\Catalog\Model\Product\Visibility::VISIBILITY_BOTH)
+        ->setWebsiteIds([$defaultWebsiteId])
+        ->setStockData(['use_config_manage_stock' => 1, 'qty' => 100, 'is_in_stock' => 1]);
+
+    if ($price !== null) {
+        $product->setPrice($price);
+    }
+
+    if ($configure !== null) {
+        $product = $configure($product) ?? $product;
+    }
+
+    $saved = $productRepository->save($product);
+    $step('product "' . $sku . '" created (' . $typeId
+        . ($price !== null ? ', $' . number_format($price, 2) : '') . ')');
+
+    $om->get(\Magento\Catalog\Api\CategoryLinkManagementInterface::class)
+        ->assignProductToCategories($sku, [$categoryId]);
+
+    return (int) $saved->getId();
+};
+
+// Virtual — no weight, no shipment.
+const VIRTUAL_SKU = 'test-virtual';
+$ensureProduct(VIRTUAL_SKU, 'Test Virtual', \Magento\Catalog\Model\Product\Type::TYPE_VIRTUAL, 10.00);
+
+// Downloadable — one URL link, included in the product price (links are not
+// purchased separately), so the line's price is a flat $10 like everything else.
+//
+// A URL link is rejected unless its host is listed in env.php's
+// downloadable_domains, so register it first — the same thing
+// `bin/magento downloadable:domains:add` does. addDomains() merges, so this is
+// idempotent.
+const DOWNLOADABLE_SKU    = 'test-downloadable';
+const DOWNLOADABLE_DOMAIN = 'example.com';
+
+$om->get(\Magento\Downloadable\Api\DomainManagerInterface::class)
+    ->addDomains([DOWNLOADABLE_DOMAIN]);
+$step('downloadable domain "' . DOWNLOADABLE_DOMAIN . '" whitelisted in env.php');
+
+$ensureProduct(
+    DOWNLOADABLE_SKU,
+    'Test Downloadable',
+    \Magento\Downloadable\Model\Product\Type::TYPE_DOWNLOADABLE,
+    10.00,
+    function ($product) use ($om) {
+        /** @var \Magento\Downloadable\Api\Data\LinkInterface $link */
+        $link = $om->create(\Magento\Downloadable\Api\Data\LinkInterfaceFactory::class)->create();
+        // Shareable explicitly, not "use config". Magento refuses guest checkout
+        // for any cart holding a downloadable whose links are not shareable, and
+        // the store default is not shareable — so LINK_SHAREABLE_CONFIG would
+        // make this product reachable only through a logged-in checkout while
+        // every other seeded type is testable as a guest.
+        $link->setTitle('Test Download')
+            ->setPrice(0)
+            ->setNumberOfDownloads(0) // unlimited
+            ->setIsShareable(\Magento\Downloadable\Model\Link::LINK_SHAREABLE_YES)
+            ->setLinkType(\Magento\Downloadable\Helper\Download::LINK_TYPE_URL)
+            ->setLinkUrl('https://example.com/taxcloud-test-download.txt')
+            ->setSortOrder(1);
+
+        $product->setLinksTitle('Test Downloads')
+            ->setLinksPurchasedSeparately(false);
+
+        $extension = $product->getExtensionAttributes();
+        $extension->setDownloadableProductLinks([$link]);
+        $product->setExtensionAttributes($extension);
+
+        return $product;
+    }
+);
+
+// Grouped — associates the simple and the virtual. Magento never puts a grouped
+// product itself in the quote: each association becomes its own top-level line
+// with its own absolute qty, which is exactly what makes it uninteresting to
+// composite tax logic and worth pinning.
+const GROUPED_SKU = 'test-grouped';
+$ensureProduct(
+    GROUPED_SKU,
+    'Test Grouped',
+    \Magento\GroupedProduct\Model\Product\Type\Grouped::TYPE_CODE,
+    null,
+    function ($product) use ($om) {
+        $associations = [
+            [PRODUCT_SKU, \Magento\Catalog\Model\Product\Type::TYPE_SIMPLE, 1, 1],
+            [VIRTUAL_SKU, \Magento\Catalog\Model\Product\Type::TYPE_VIRTUAL, 1, 2],
+        ];
+
+        $links = [];
+        foreach ($associations as [$linkedSku, $linkedType, $qty, $position]) {
+            /** @var \Magento\Catalog\Api\Data\ProductLinkInterface $link */
+            $link = $om->create(\Magento\Catalog\Api\Data\ProductLinkInterfaceFactory::class)->create();
+            $link->setSku(GROUPED_SKU)
+                ->setLinkType('associated')
+                ->setLinkedProductSku($linkedSku)
+                ->setLinkedProductType($linkedType)
+                ->setPosition($position);
+
+            // qty lives on the link's extension attributes, and the getter
+            // returns null until one is created.
+            $linkExtension = $link->getExtensionAttributes()
+                ?: $om->create(\Magento\Catalog\Api\Data\ProductLinkExtensionFactory::class)->create();
+            $linkExtension->setQty($qty);
+            $link->setExtensionAttributes($linkExtension);
+
+            $links[] = $link;
+        }
+
+        $product->setProductLinks($links);
+
+        return $product;
+    }
+);
+
+// Bundles. Selections are built the same way for both; only the price type and
+// what carries the price differ.
+const BUNDLE_DYNAMIC_SKU = 'test-bundle-dynamic';
+const BUNDLE_FIXED_SKU   = 'test-bundle-fixed';
+const BUNDLE_FIXED_PRICE = 50.00;
+
+/**
+ * One required checkbox option holding the given selections, both checked by
+ * default so Add to Cart works on the storefront without any interaction.
+ *
+ * @param array $selections [sku, qty] pairs
+ */
+$bundleOption = function (string $parentSku, string $title, array $selections, int $priceType) use ($om) {
+    $links = [];
+    $position = 1;
+    foreach ($selections as [$selectionSku, $selectionQty]) {
+        /** @var \Magento\Bundle\Api\Data\LinkInterface $link */
+        $link = $om->create(\Magento\Bundle\Api\Data\LinkInterfaceFactory::class)->create();
+        $link->setSku($selectionSku)
+            ->setQty($selectionQty)
+            ->setCanChangeQuantity(0)
+            ->setIsDefault(true)
+            ->setPosition($position++)
+            ->setPriceType($priceType)
+            ->setPrice(0.00);
+        $links[] = $link;
+    }
+
+    /** @var \Magento\Bundle\Api\Data\OptionInterface $option */
+    $option = $om->create(\Magento\Bundle\Api\Data\OptionInterfaceFactory::class)->create();
+    $option->setTitle($title)
+        ->setType('checkbox')
+        ->setRequired(true)
+        ->setPosition(1)
+        ->setSku($parentSku)
+        ->setProductLinks($links);
+
+    return $option;
+};
+
+// Dynamic: the parent has no price of its own — it is the sum of the selections,
+// $10 + (2 x $10) = $30 per bundle. The qty-2 selection is deliberate: its quote
+// line stores qty 2 per bundle, so a qty-3 cart has to reach TaxCloud as 6.
+$ensureProduct(
+    BUNDLE_DYNAMIC_SKU,
+    'Test Bundle Dynamic',
+    \Magento\Catalog\Model\Product\Type::TYPE_BUNDLE,
+    null,
+    function ($product) use ($om, $bundleOption) {
+        $product->setPriceType(\Magento\Bundle\Model\Product\Price::PRICE_TYPE_DYNAMIC)
+            ->setSkuType(0)      // dynamic sku: parent sku grows the selection skus
+            ->setWeightType(0)   // dynamic weight
+            ->setPriceView(0)    // price range
+            ->setShipmentType(\Magento\Bundle\Model\Product\Type::SHIPMENT_TOGETHER);
+
+        $extension = $product->getExtensionAttributes();
+        $extension->setBundleProductOptions([
+            $bundleOption(
+                BUNDLE_DYNAMIC_SKU,
+                'Dynamic Selections',
+                [[PRODUCT_SKU, 1], [VIRTUAL_SKU, 2]],
+                \Magento\Bundle\Model\Product\Price::PRICE_TYPE_DYNAMIC
+            ),
+        ]);
+        $product->setExtensionAttributes($extension);
+
+        return $product;
+    }
+);
+
+// Fixed: the control case. The parent carries the whole $50 and the selections
+// are priced at 0, so Magento maps only the parent into the tax details.
+$ensureProduct(
+    BUNDLE_FIXED_SKU,
+    'Test Bundle Fixed',
+    \Magento\Catalog\Model\Product\Type::TYPE_BUNDLE,
+    BUNDLE_FIXED_PRICE,
+    function ($product) use ($om, $bundleOption) {
+        $product->setPriceType(\Magento\Bundle\Model\Product\Price::PRICE_TYPE_FIXED)
+            ->setSkuType(1)      // fixed sku: the parent sku is the order sku
+            ->setWeightType(1)
+            ->setWeight(1)
+            ->setPriceView(0)
+            ->setShipmentType(\Magento\Bundle\Model\Product\Type::SHIPMENT_TOGETHER);
+
+        $extension = $product->getExtensionAttributes();
+        $extension->setBundleProductOptions([
+            $bundleOption(
+                BUNDLE_FIXED_SKU,
+                'Fixed Selections',
+                [[PRODUCT_SKU, 1]],
+                \Magento\Bundle\Model\Product\Price::PRICE_TYPE_FIXED
+            ),
+        ]);
+        $product->setExtensionAttributes($extension);
+
+        return $product;
+    }
+);
+
+// Gift card — Adobe Commerce only. Guarded on the module being both present and
+// enabled, so this whole block is a no-op on Open Source rather than a fatal.
+const GIFTCARD_SKU    = 'test-giftcard';
+const GIFTCARD_AMOUNT = 25.00;
+
+$giftcardSeeded = false;
+if ($om->get(\Magento\Framework\Module\Manager::class)->isEnabled('Magento_GiftCard')
+    && class_exists(\Magento\GiftCard\Model\Catalog\Product\Type\Giftcard::class)
+) {
+    $ensureProduct(
+        GIFTCARD_SKU,
+        'Test Gift Card',
+        \Magento\GiftCard\Model\Catalog\Product\Type\Giftcard::TYPE_GIFTCARD,
+        null,
+        function ($product) use ($om) {
+            // Virtual: emailed, so it never adds a shippable line.
+            $product->setGiftcardType(\Magento\GiftCard\Model\Giftcard::TYPE_VIRTUAL)
+                ->setAllowOpenAmount(\Magento\GiftCard\Model\Giftcard::OPEN_AMOUNT_DISABLED)
+                ->setUseConfigIsRedeemable(1)
+                ->setUseConfigLifetime(1)
+                ->setUseConfigAllowMessage(1)
+                ->setUseConfigEmailTemplate(1);
+
+            // Amounts go on the EXTENSION attributes, not setGiftcardAmounts():
+            // GiftCard\Model\Product\SaveHandler reads
+            // getExtensionAttributes()->getGiftcardAmounts() and ignores the data
+            // array entirely, so a plain setter is dropped without complaint —
+            // and a card with neither a stored amount nor an open amount reports
+            // itself unsalable, failing add to cart with a bare "Product that you
+            // are trying to add is not available."
+            //
+            // website_id 0 is the "All Websites" scope the backend model requires.
+            /** @var \Magento\GiftCard\Api\Data\GiftcardAmountInterface $amount */
+            $amount = $om->create(\Magento\GiftCard\Api\Data\GiftcardAmountInterfaceFactory::class)->create();
+            $amount->setWebsiteId(0)->setValue(GIFTCARD_AMOUNT);
+
+            $extension = $product->getExtensionAttributes();
+            $extension->setGiftcardAmounts([$amount]);
+            $product->setExtensionAttributes($extension);
+
+            return $product;
+        }
+    );
+    $giftcardSeeded = true;
+} else {
+    $step('gift card skipped (Magento_GiftCard not available — Open Source)');
+}
+
+// --- 4h. Registered customer + default address ------------------------------
 //
 // A storefront customer with a default shipping/billing address, for E2E tests
 // that exercise logged-in flows (e.g. tax shown in the cart before checkout).
@@ -418,7 +900,7 @@ $customerRepository = $om->get(\Magento\Customer\Api\CustomerRepositoryInterface
 
 // Customer accounts are scoped PER WEBSITE (customer/account_share/scope
 // default). The same email on two websites is two independent accounts, so the
-// second store (section 4d) gets its own record with the SAME credentials —
+// second store (section 4i) gets its own record with the SAME credentials —
 // tests log in with one email/password everywhere and the website context
 // picks the account. Callable per store view; idempotent per website.
 $ensureCustomer = function (\Magento\Store\Api\Data\StoreInterface $store) use (
@@ -478,116 +960,143 @@ $ensureCustomer = function (\Magento\Store\Api\Data\StoreInterface $store) use (
 // getDefaultStoreView(), NOT getStore(): the current store was pinned to the
 // admin scope at bootstrap, and a customer created there (website_id 0) can't
 // log in on any storefront under per-website account sharing.
-$ensureCustomer($storeManager->getDefaultStoreView());
+if ($productsOnly) {
+    $step('skipped test customer (--products-only)');
+} else {
+    $ensureCustomer($storeManager->getDefaultStoreView());
+}
 
-// --- 4d. Second website / store group / store view (multi-store) -------------
+// --- 4i. Second website / store group / store view (multi-store) -------------
 //
-// A complete second scope tree (website "second" -> group "second" -> store
-// view "second") sharing the main root category, so the same test catalog is
-// browsable on both stores. Combined with web/url/use_store=1 (section 2) the
-// storefronts live on one base URL as /default/... and /second/....
-//
-// TaxCloud is explicitly DISABLED on the second store via a store-scope config
-// override (the module reads tax/taxcloud_settings/enabled at SCOPE_STORE, see
-// Model/Tax.php), so multi-store tests can prove scope isolation: carts on
-// "second" must fall back to native Magento tax, never hitting TaxCloud.
-//
-// Saving through the resource models (not raw SQL) fires the real plugins and
-// events: MSI links the new website to the Default Stock, and Magento_Sales
-// creates the sales sequence tables for the new store. Idempotent.
+// Skipped by --products-only: a second website is a structural change to the
+// store, not a test fixture.
 
+// Declared outside the guard below: const is only legal at the top level, and
+// the closing summary reads these whether or not the scope tree was built.
 const SECOND_WEBSITE_CODE = 'second';
 const SECOND_GROUP_CODE   = 'second';
 const SECOND_STORE_CODE   = 'second';
 
-/** @var \Magento\Store\Model\ResourceModel\Website $websiteResource */
-$websiteResource = $om->get(\Magento\Store\Model\ResourceModel\Website::class);
-/** @var \Magento\Store\Model\Website $secondWebsite */
-$secondWebsite = $om->create(\Magento\Store\Model\WebsiteFactory::class)->create();
-$websiteResource->load($secondWebsite, SECOND_WEBSITE_CODE, 'code');
-if ($secondWebsite->getId()) {
-    $step('website "' . SECOND_WEBSITE_CODE . '" already exists (id ' . $secondWebsite->getId() . ')');
+if ($productsOnly) {
+    $step('skipped second website / store view (--products-only)');
 } else {
-    $secondWebsite->setCode(SECOND_WEBSITE_CODE)
-        ->setName('Second Website')
-        ->setSortOrder(10);
-    $websiteResource->save($secondWebsite);
-    $step('website "' . SECOND_WEBSITE_CODE . '" created (id ' . $secondWebsite->getId() . ')');
-}
+    //
+    // A complete second scope tree (website "second" -> group "second" -> store
+    // view "second") sharing the main root category, so the same test catalog is
+    // browsable on both stores. Combined with web/url/use_store=1 (section 2) the
+    // storefronts live on one base URL as /default/... and /second/....
+    //
+    // TaxCloud is explicitly DISABLED on the second store via a store-scope config
+    // override (the module reads tax/taxcloud_settings/enabled at SCOPE_STORE, see
+    // Model/Tax.php), so multi-store tests can prove scope isolation: carts on
+    // "second" must fall back to native Magento tax, never hitting TaxCloud.
+    //
+    // Saving through the resource models (not raw SQL) fires the real plugins and
+    // events: MSI links the new website to the Default Stock, and Magento_Sales
+    // creates the sales sequence tables for the new store. Idempotent.
 
-/** @var \Magento\Store\Model\ResourceModel\Group $groupResource */
-$groupResource = $om->get(\Magento\Store\Model\ResourceModel\Group::class);
-/** @var \Magento\Store\Model\Group $secondGroup */
-$secondGroup = $om->create(\Magento\Store\Model\GroupFactory::class)->create();
-$groupResource->load($secondGroup, SECOND_GROUP_CODE, 'code');
-if ($secondGroup->getId()) {
-    $step('store group "' . SECOND_GROUP_CODE . '" already exists (id ' . $secondGroup->getId() . ')');
-} else {
-    $secondGroup->setWebsiteId((int) $secondWebsite->getId())
-        ->setCode(SECOND_GROUP_CODE)
-        ->setName('Second Store')
-        ->setRootCategoryId($rootCategoryId);
-    $groupResource->save($secondGroup);
-    $step('store group "' . SECOND_GROUP_CODE . '" created (id ' . $secondGroup->getId()
-        . ", root category $rootCategoryId)");
-}
+    /** @var \Magento\Store\Model\ResourceModel\Website $websiteResource */
+    $websiteResource = $om->get(\Magento\Store\Model\ResourceModel\Website::class);
+    /** @var \Magento\Store\Model\Website $secondWebsite */
+    $secondWebsite = $om->create(\Magento\Store\Model\WebsiteFactory::class)->create();
+    $websiteResource->load($secondWebsite, SECOND_WEBSITE_CODE, 'code');
+    if ($secondWebsite->getId()) {
+        $step('website "' . SECOND_WEBSITE_CODE . '" already exists (id ' . $secondWebsite->getId() . ')');
+    } else {
+        $secondWebsite->setCode(SECOND_WEBSITE_CODE)
+            ->setName('Second Website')
+            ->setSortOrder(10);
+        $websiteResource->save($secondWebsite);
+        $step('website "' . SECOND_WEBSITE_CODE . '" created (id ' . $secondWebsite->getId() . ')');
+    }
 
-/** @var \Magento\Store\Model\ResourceModel\Store $storeResource */
-$storeResource = $om->get(\Magento\Store\Model\ResourceModel\Store::class);
-/** @var \Magento\Store\Model\Store $secondStore */
-$secondStore = $om->create(\Magento\Store\Model\StoreFactory::class)->create();
-$storeResource->load($secondStore, SECOND_STORE_CODE, 'code');
-if ($secondStore->getId()) {
-    $step('store view "' . SECOND_STORE_CODE . '" already exists (id ' . $secondStore->getId() . ')');
-} else {
-    $secondStore->setCode(SECOND_STORE_CODE)
-        ->setName('Second Store View')
-        ->setWebsiteId((int) $secondWebsite->getId())
-        ->setGroupId((int) $secondGroup->getId())
-        ->setSortOrder(10)
-        ->setIsActive(1);
-    $storeResource->save($secondStore);
-    $step('store view "' . SECOND_STORE_CODE . '" created (id ' . $secondStore->getId() . ')');
-}
+    /** @var \Magento\Store\Model\ResourceModel\Group $groupResource */
+    $groupResource = $om->get(\Magento\Store\Model\ResourceModel\Group::class);
+    /** @var \Magento\Store\Model\Group $secondGroup */
+    $secondGroup = $om->create(\Magento\Store\Model\GroupFactory::class)->create();
+    $groupResource->load($secondGroup, SECOND_GROUP_CODE, 'code');
+    if ($secondGroup->getId()) {
+        $step('store group "' . SECOND_GROUP_CODE . '" already exists (id ' . $secondGroup->getId() . ')');
+    } else {
+        $secondGroup->setWebsiteId((int) $secondWebsite->getId())
+            ->setCode(SECOND_GROUP_CODE)
+            ->setName('Second Store')
+            ->setRootCategoryId($rootCategoryId);
+        $groupResource->save($secondGroup);
+        $step('store group "' . SECOND_GROUP_CODE . '" created (id ' . $secondGroup->getId()
+            . ", root category $rootCategoryId)");
+    }
 
-// Wire the defaults so the new scope tree is fully navigable.
-if ((int) $secondGroup->getDefaultStoreId() !== (int) $secondStore->getId()) {
-    $secondGroup->setDefaultStoreId((int) $secondStore->getId());
-    $groupResource->save($secondGroup);
-}
-if ((int) $secondWebsite->getDefaultGroupId() !== (int) $secondGroup->getId()) {
-    $secondWebsite->setDefaultGroupId((int) $secondGroup->getId());
-    $websiteResource->save($secondWebsite);
-}
-$step('scope tree wired: website "' . SECOND_WEBSITE_CODE . '" -> group "'
-    . SECOND_GROUP_CODE . '" -> store "' . SECOND_STORE_CODE . '"');
+    /** @var \Magento\Store\Model\ResourceModel\Store $storeResource */
+    $storeResource = $om->get(\Magento\Store\Model\ResourceModel\Store::class);
+    /** @var \Magento\Store\Model\Store $secondStore */
+    $secondStore = $om->create(\Magento\Store\Model\StoreFactory::class)->create();
+    $storeResource->load($secondStore, SECOND_STORE_CODE, 'code');
+    if ($secondStore->getId()) {
+        $step('store view "' . SECOND_STORE_CODE . '" already exists (id ' . $secondStore->getId() . ')');
+    } else {
+        $secondStore->setCode(SECOND_STORE_CODE)
+            ->setName('Second Store View')
+            ->setWebsiteId((int) $secondWebsite->getId())
+            ->setGroupId((int) $secondGroup->getId())
+            ->setSortOrder(10)
+            ->setIsActive(1);
+        $storeResource->save($secondStore);
+        $step('store view "' . SECOND_STORE_CODE . '" created (id ' . $secondStore->getId() . ')');
+    }
 
-// Make the whole test catalog visible on the second website too.
-$secondWebsiteId = (int) $secondWebsite->getId();
-$catalogSkus = [PRODUCT_SKU, CONFIGURABLE_SKU, VARIANT_RED_SKU, VARIANT_BLUE_SKU];
-$catalogIds = [];
-foreach ($catalogSkus as $sku) {
-    $catalogIds[] = (int) $productRepository->get($sku)->getId();
-}
-$om->get(\Magento\Catalog\Model\Product\Action::class)
-    ->updateWebsites($catalogIds, [$secondWebsiteId], 'add');
-$step('test catalog (' . implode(', ', $catalogSkus) . ") assigned to website $secondWebsiteId");
+    // Wire the defaults so the new scope tree is fully navigable.
+    if ((int) $secondGroup->getDefaultStoreId() !== (int) $secondStore->getId()) {
+        $secondGroup->setDefaultStoreId((int) $secondStore->getId());
+        $groupResource->save($secondGroup);
+    }
+    if ((int) $secondWebsite->getDefaultGroupId() !== (int) $secondGroup->getId()) {
+        $secondWebsite->setDefaultGroupId((int) $secondGroup->getId());
+        $websiteResource->save($secondWebsite);
+    }
+    $step('scope tree wired: website "' . SECOND_WEBSITE_CODE . '" -> group "'
+        . SECOND_GROUP_CODE . '" -> store "' . SECOND_STORE_CODE . '"');
 
-// Disable TaxCloud on the second store only (store-scope override).
-$disabledValue = $preparedValueFactory->create(
-    'tax/taxcloud_settings/enabled',
-    '0',
-    \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
-    SECOND_STORE_CODE
-);
-if ($disabledValue instanceof \Magento\Framework\App\Config\Value) {
-    $disabledValue->getResource()->save($disabledValue);
-}
-$step('config tax/taxcloud_settings/enabled = 0 (scope stores/' . SECOND_STORE_CODE . ')');
+    // Make the whole test catalog visible on the second website too.
+    $secondWebsiteId = (int) $secondWebsite->getId();
+    $catalogSkus = [
+        PRODUCT_SKU,
+        CONFIGURABLE_SKU,
+        VARIANT_RED_SKU,
+        VARIANT_BLUE_SKU,
+        VIRTUAL_SKU,
+        DOWNLOADABLE_SKU,
+        GROUPED_SKU,
+        BUNDLE_DYNAMIC_SKU,
+        BUNDLE_FIXED_SKU,
+    ];
+    if ($giftcardSeeded) {
+        $catalogSkus[] = GIFTCARD_SKU;
+    }
+    $catalogIds = [];
+    foreach ($catalogSkus as $sku) {
+        $catalogIds[] = (int) $productRepository->get($sku)->getId();
+    }
+    $om->get(\Magento\Catalog\Model\Product\Action::class)
+        ->updateWebsites($catalogIds, [$secondWebsiteId], 'add');
+    $step('test catalog (' . implode(', ', $catalogSkus) . ") assigned to website $secondWebsiteId");
 
-// Same credentials, second website: accounts are per-website (section 4c), so
-// the second store needs its own customer record for logged-in test flows.
-$ensureCustomer($secondStore);
+    // Disable TaxCloud on the second store only (store-scope override).
+    $disabledValue = $preparedValueFactory->create(
+        'tax/taxcloud_settings/enabled',
+        '0',
+        \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
+        SECOND_STORE_CODE
+    );
+    if ($disabledValue instanceof \Magento\Framework\App\Config\Value) {
+        $disabledValue->getResource()->save($disabledValue);
+    }
+    $step('config tax/taxcloud_settings/enabled = 0 (scope stores/' . SECOND_STORE_CODE . ')');
+
+    // Same credentials, second website: accounts are per-website (section 4h), so
+    // the second store needs its own customer record for logged-in test flows.
+    $ensureCustomer($secondStore);
+}
 
 // --- 5. Reindex + cache flush --------------------------------------------------
 
@@ -603,13 +1112,27 @@ $cacheManager = $om->get(\Magento\Framework\App\Cache\Manager::class);
 $cacheManager->flush($cacheManager->getAvailableTypes());
 $step('flushed all caches');
 
-echo "\n[seed] Done. Test environment ready:\n";
-echo '       admin:    ' . ADMIN_USERNAME . ' / ' . ADMIN_PASSWORD . ' <' . ADMIN_EMAIL . ">\n";
-echo '       customer: ' . CUSTOMER_EMAIL . ' / ' . CUSTOMER_PASSWORD
-    . " (default addr Austin TX; one account per website, same creds)\n";
+echo "\n[seed] Done. " . ($productsOnly ? "Catalog seeded (--products-only):\n" : "Test environment ready:\n");
+if (!$productsOnly) {
+    echo '       admin:    ' . ADMIN_USERNAME . ' / ' . ADMIN_PASSWORD . ' <' . ADMIN_EMAIL . ">\n";
+    echo '       customer: ' . CUSTOMER_EMAIL . ' / ' . CUSTOMER_PASSWORD
+        . " (default addr Austin TX; one account per website, same creds)\n";
+}
 echo '       category: ' . CATEGORY_NAME . ' (' . CATEGORY_URL_KEY . ")\n";
 echo '       product:  ' . PRODUCT_SKU . ' ($' . number_format(PRODUCT_PRICE, 2) . ")\n";
 echo '       config.:  ' . CONFIGURABLE_SKU . ' (' . VARIANT_RED_SKU . ' tic '
     . VARIANT_RED_TIC . ', ' . VARIANT_BLUE_SKU . ' tic ' . VARIANT_BLUE_TIC . ")\n";
-echo '       stores:   /default/ (TaxCloud ON), /' . SECOND_STORE_CODE
-    . "/ (TaxCloud OFF; store codes in URLs enabled)\n";
+echo '       types:    ' . VIRTUAL_SKU . ', ' . DOWNLOADABLE_SKU . ', ' . GROUPED_SKU
+    . ' ($10 each)' . "\n";
+echo '                 ' . BUNDLE_DYNAMIC_SKU . ' ($30/bundle: 1x ' . PRODUCT_SKU
+    . ' + 2x ' . VIRTUAL_SKU . '), ' . BUNDLE_FIXED_SKU
+    . ' ($' . number_format(BUNDLE_FIXED_PRICE, 2) . ")\n";
+echo '                 ' . ($giftcardSeeded
+    ? GIFTCARD_SKU . ' ($' . number_format(GIFTCARD_AMOUNT, 2) . ', virtual)'
+    : 'giftcard skipped (Open Source)') . "\n";
+if (!$productsOnly) {
+    echo '       stores:   /default/ (TaxCloud ON), /' . SECOND_STORE_CODE
+        . "/ (TaxCloud OFF; store codes in URLs enabled)\n";
+} else {
+    echo "       untouched: configuration, admin user, customers, scope tree\n";
+}

--- a/scripts/verify-test-products.php
+++ b/scripts/verify-test-products.php
@@ -1,0 +1,277 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Prove the seeded catalog is usable: every product loads, is enabled and
+ * visible, and can actually be added to a cart.
+ *
+ * "Exists in the DB" is not the bar — a product can be saved and still be
+ * unbuyable (disabled by Content Staging, not salable because an index is
+ * stale, a bundle with no default selection). This adds each seeded SKU to a
+ * real quote through Quote::addProduct() — the same call the storefront makes —
+ * and prints the quote lines that result, so the composite shapes are visible
+ * too: which line carries the price, and what quantity each one stores.
+ *
+ * The quote is built in memory and never saved, so this is read-only against
+ * the catalog and writes nothing.
+ *
+ * Usage:  php verify-test-products.php [magento-root]
+ *
+ * Exit code is 0 only if every product was added successfully.
+ */
+
+declare(strict_types=1);
+
+if (PHP_SAPI !== 'cli') {
+    exit(1);
+}
+
+error_reporting(E_ALL);
+
+$candidates = array_filter([
+    $argv[1] ?? null,
+    getenv('MAGENTO_ROOT') ?: null,
+    getcwd() ?: null,
+    dirname(__DIR__, 5), // app/code/Taxcloud/Magento2/scripts -> magento root
+]);
+
+$magentoRoot = null;
+foreach ($candidates as $candidate) {
+    if (is_file($candidate . '/app/bootstrap.php')) {
+        $magentoRoot = realpath($candidate);
+        break;
+    }
+}
+if ($magentoRoot === null) {
+    fwrite(STDERR, "ERROR: could not find a Magento install (app/bootstrap.php).\n");
+    exit(1);
+}
+
+require $magentoRoot . '/app/bootstrap.php';
+
+$bootstrap = \Magento\Framework\App\Bootstrap::create(BP, $_SERVER);
+$om = $bootstrap->getObjectManager();
+
+try {
+    $om->get(\Magento\Framework\App\State::class)
+        ->setAreaCode(\Magento\Framework\App\Area::AREA_FRONTEND);
+} catch (\Magento\Framework\Exception\LocalizedException $e) {
+    // area already set
+}
+
+/** @var \Magento\Store\Model\StoreManagerInterface $storeManager */
+$storeManager = $om->get(\Magento\Store\Model\StoreManagerInterface::class);
+$store = $storeManager->getDefaultStoreView();
+$storeManager->setCurrentStore($store);
+
+/** @var \Magento\Catalog\Api\ProductRepositoryInterface $productRepository */
+$productRepository = $om->get(\Magento\Catalog\Api\ProductRepositoryInterface::class);
+
+/**
+ * The seeded catalog, with the buy request each type needs. A type whose add to
+ * cart needs no options (simple, virtual, downloadable) just carries a qty.
+ * Anything missing from the catalog is reported as skipped, not failed — the
+ * gift card only exists on Adobe Commerce.
+ */
+$cases = [
+    ['sku' => 'test-product',     'qty' => 1, 'options' => []],
+    ['sku' => 'test-virtual',     'qty' => 1, 'options' => []],
+    ['sku' => 'test-downloadable', 'qty' => 1, 'options' => []],
+    ['sku' => 'test-configurable', 'qty' => 1, 'options' => 'configurable'],
+    ['sku' => 'test-grouped',     'qty' => 1, 'options' => 'grouped'],
+    // qty 3 on purpose: the bundle selection stored at qty 2 has to reach the
+    // quote as 6, which is the arithmetic the composite handling turns on.
+    ['sku' => 'test-bundle-dynamic', 'qty' => 3, 'options' => 'bundle'],
+    ['sku' => 'test-bundle-fixed',   'qty' => 1, 'options' => 'bundle'],
+    ['sku' => 'test-giftcard',       'qty' => 1, 'options' => 'giftcard'],
+];
+
+/**
+ * Build the buy request for a product, choosing the first available value for
+ * each required option so the add is deterministic.
+ */
+$buyRequestFor = function (\Magento\Catalog\Api\Data\ProductInterface $product, $kind, int $qty) use ($om): array {
+    $request = ['qty' => $qty];
+
+    if ($kind === 'configurable') {
+        $typeInstance = $product->getTypeInstance();
+        $attributes = $typeInstance->getConfigurableAttributesAsArray($product);
+        $superAttribute = [];
+        foreach ($attributes as $attribute) {
+            $superAttribute[$attribute['attribute_id']] = $attribute['values'][0]['value_index'];
+        }
+        $request['super_attribute'] = $superAttribute;
+    }
+
+    if ($kind === 'grouped') {
+        $superGroup = [];
+        foreach ($product->getTypeInstance()->getAssociatedProducts($product) as $associated) {
+            $superGroup[$associated->getId()] = 1;
+        }
+        $request['super_group'] = $superGroup;
+    }
+
+    if ($kind === 'bundle') {
+        $bundleOption = [];
+        $bundleOptionQty = [];
+        $options = $product->getTypeInstance()->getOptionsCollection($product);
+        $selections = $product->getTypeInstance()
+            ->getSelectionsCollection($options->getAllIds(), $product);
+        foreach ($options as $option) {
+            $ids = [];
+            foreach ($selections as $selection) {
+                if ((int) $selection->getOptionId() === (int) $option->getId()) {
+                    $ids[] = (int) $selection->getSelectionId();
+                    $bundleOptionQty[(int) $option->getId()] = (int) $selection->getSelectionQty();
+                }
+            }
+            if ($ids) {
+                // checkbox options take an array of selection ids
+                $bundleOption[(int) $option->getId()] = $ids;
+            }
+        }
+        $request['bundle_option'] = $bundleOption;
+        $request['bundle_option_qty'] = $bundleOptionQty;
+    }
+
+    if ($kind === 'giftcard') {
+        $request['giftcard_amount'] = $product->getGiftcardAmounts()[0]['value']
+            ?? $product->getGiftcardAmounts()[0]['website_value']
+            ?? 25.00;
+        $request['giftcard_sender_name'] = 'Test Sender';
+        $request['giftcard_sender_email'] = 'sender@example.com';
+        $request['giftcard_recipient_name'] = 'Test Recipient';
+        $request['giftcard_recipient_email'] = 'recipient@example.com';
+    }
+
+    return $request;
+};
+
+/**
+ * The SKUs the Test Category page would actually list, built with the same
+ * store, category, status and visibility filters the storefront product list
+ * applies. Checking the visibility attribute alone would not catch a product
+ * that is enabled and visible but missing from the category index.
+ */
+$listedSkus = [];
+$categoryCollection = $om->create(\Magento\Catalog\Model\ResourceModel\Category\CollectionFactory::class)
+    ->create()
+    ->addAttributeToFilter('url_key', 'test-category')
+    ->setPageSize(1);
+
+if ($categoryCollection->getSize()) {
+    $category = $om->create(\Magento\Catalog\Model\CategoryFactory::class)
+        ->create()
+        ->setStoreId((int) $store->getId())
+        ->load((int) $categoryCollection->getFirstItem()->getId());
+
+    $listing = $om->create(\Magento\Catalog\Model\ResourceModel\Product\CollectionFactory::class)->create();
+    $listing->setStore($store)
+        ->addAttributeToSelect('sku')
+        ->addCategoryFilter($category)
+        ->setVisibility($om->get(\Magento\Catalog\Model\Product\Visibility::class)->getVisibleInCatalogIds())
+        ->addAttributeToFilter('status', \Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED);
+
+    foreach ($listing as $listed) {
+        $listedSkus[$listed->getSku()] = true;
+    }
+    echo 'Test Category lists ' . count($listedSkus) . " product(s)\n\n";
+} else {
+    echo "WARNING: Test Category not found; skipping the listing check\n\n";
+}
+
+$failures = 0;
+$skipped = [];
+
+foreach ($cases as $case) {
+    $sku = $case['sku'];
+
+    try {
+        $product = $productRepository->get($sku, false, (int) $store->getId());
+    } catch (\Magento\Framework\Exception\NoSuchEntityException $e) {
+        $skipped[] = $sku;
+        echo "SKIP  $sku — not in this catalog\n";
+        continue;
+    }
+
+    $status = (int) $product->getStatus();
+    $visibility = (int) $product->getVisibility();
+    $enabled = $status === \Magento\Catalog\Model\Product\Attribute\Source\Status::STATUS_ENABLED;
+    $visible = $visibility !== \Magento\Catalog\Model\Product\Visibility::VISIBILITY_NOT_VISIBLE;
+
+    // A fresh quote per product, so one failure cannot cascade into the next.
+    /** @var \Magento\Quote\Model\Quote $quote */
+    $quote = $om->create(\Magento\Quote\Model\QuoteFactory::class)->create();
+    $quote->setStore($store);
+
+    $addError = null;
+    try {
+        $request = new \Magento\Framework\DataObject(
+            $buyRequestFor($product, $case['options'], $case['qty'])
+        );
+        $result = $quote->addProduct($product, $request);
+        if (is_string($result)) {
+            // addProduct returns the error message as a string rather than throwing
+            $addError = $result;
+        }
+    } catch (\Throwable $e) {
+        $addError = get_class($e) . ': ' . $e->getMessage();
+    }
+
+    // count(getAllItems()), not getItemsCount(): the latter reads a quote field
+    // that is only maintained once the quote is saved, and this one never is.
+    $lines = $quote->getAllItems();
+    $listed = $listedSkus === [] || isset($listedSkus[$sku]);
+    $ok = $enabled && $visible && $listed && $addError === null && count($lines) > 0;
+    if (!$ok) {
+        $failures++;
+    }
+
+    printf(
+        "%-5s %-22s %-13s %-9s %-12s %s\n",
+        $ok ? 'OK' : 'FAIL',
+        $sku,
+        $product->getTypeId(),
+        $enabled ? 'enabled' : 'DISABLED',
+        $visible ? 'visible' : 'NOT VISIBLE',
+        $listed ? 'in category' : 'NOT IN CATEGORY'
+    );
+
+    if ($addError !== null) {
+        echo "      add to cart failed: $addError\n";
+        continue;
+    }
+
+    // Print the quote lines this product produced. For composites this is the
+    // interesting part: which lines exist, which one carries the price, and the
+    // qty each one stores. A bundle child stores its qty PER PARENT, so the
+    // effective quantity — what a tax service has to be told — is the product of
+    // the two. Row totals are not shown: they are only populated by
+    // collectTotals(), which this deliberately does not run.
+    foreach ($lines as $item) {
+        $parent = $item->getParentItem();
+        $qty = (float) $item->getQty();
+        printf(
+            "      %s%-44s qty %-5s price %-7s%s\n",
+            $parent ? '↳ ' : '  ',
+            $item->getSku(),
+            rtrim(rtrim(number_format($qty, 4, '.', ''), '0'), '.'),
+            number_format((float) $item->getPrice(), 2),
+            $parent
+                ? sprintf(' x parent qty %g = %g effective', (float) $parent->getQty(), $qty * (float) $parent->getQty())
+                : ''
+        );
+    }
+}
+
+echo "\n";
+if ($skipped) {
+    echo 'skipped: ' . implode(', ', $skipped) . "\n";
+}
+
+if ($failures > 0) {
+    echo "$failures product(s) FAILED\n";
+    exit(1);
+}
+
+echo "all seeded products load, are enabled and visible, and add to cart\n";
+exit(0);


### PR DESCRIPTION
## What's in this release

- **DEV-9436** — bundle tax calculation fixes plus unit, integration and E2E coverage (cherry-picked from `1.3.0` as `9a9290b`).
- Version bump to `1.3.1` across `composer.json`, `etc/module.xml` (`setup_version`) and the README version line. The `## 1.3.1` CHANGELOG section already shipped with DEV-9436; only the manifests had been missed, so `main` was carrying changed code under the already-tagged `1.3.0`.

## Why this is a cherry-pick and not a merge of `1.3.0`

Merging `origin/1.3.0` into `main` produced conflicts in 8 files — all of them spurious. `1.3.0` was **squash-merged** into `main` as `c0504cd "1.3.0 (#31)"`, which discarded the ancestry link to that branch's ~100 commits. The last back-merge on `1.3.0` (`bab471a`) had pulled in `4a89ffc` (v1.2.0), so:

```
git merge-base main origin/1.3.0  ->  4a89ffc  ("1.2.0 (#29)")
```

With a merge base predating all of 1.3.0, git saw both sides independently *creating* every 1.3.0 file, giving `both added` conflicts with no common ancestor to diff against — so every difference conflicted, including where one side was a pure superset of the other.

`tree(c0504cd)` is byte-identical to `tree(d550d6b)`, i.e. `main` already contained 1.3.0 exactly, minus the new feature. So the only genuinely new content was the single commit `9a9290b`, which cherry-picks onto `main` with zero conflicts and reproduces `origin/1.3.0`'s tree hash exactly.

## Verification

| Gate | Result |
|---|---|
| `make test-unit` | OK — 510 tests, 1124 assertions |
| `make phpstan` | No errors (level 5) |
| `make lint` | 40/40 files clean |

Diff against `origin/1.3.0`'s tip is exactly the three version lines — nothing from 1.3.0 is left behind.

## After merging

1. Tag the squash commit `v1.3.1` (not done yet — the tag belongs on the commit that lands here).
2. `1.3.0` is now disconnected and stale. Reset it onto `main` or delete it, and branch fresh from `main` for 1.3.x follow-ups — continuing to commit on a squash-merged release branch is what caused the conflicts above.
3. `bugfix/NEW-DEV-9436-all-product-types-coverage` carries a separate 1.4.0 port of this same fix; worth confirming the two don't diverge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)